### PR TITLE
current version + versionConflictToken not required to be nil

### DIFF
--- a/api/v1alpha1/worker_types.go
+++ b/api/v1alpha1/worker_types.go
@@ -108,8 +108,9 @@ type TemporalWorkerDeploymentStatus struct {
 	TargetVersion *TargetWorkerDeploymentVersion `json:"targetVersion"`
 
 	// CurrentVersion is the version that is currently registered with
-	// Temporal as the current version of its worker deployment. This must never be nil.
-	CurrentVersion *CurrentWorkerDeploymentVersion `json:"currentVersion"`
+	// Temporal as the current version of its worker deployment. This will be nil
+	// during initial bootstrap until a version is registered and set as current.
+	CurrentVersion *CurrentWorkerDeploymentVersion `json:"currentVersion,omitempty"`
 
 	// RampingVersion is the version that is currently registered with
 	// Temporal as the ramping version of its worker deployment. The controller
@@ -124,7 +125,7 @@ type TemporalWorkerDeploymentStatus struct {
 	// VersionConflictToken prevents concurrent modifications to the deployment status.
 	// It ensures reconciliation operations don't inadvertently override changes made
 	// by external systems while processing is underway.
-	VersionConflictToken []byte `json:"versionConflictToken"`
+	VersionConflictToken []byte `json:"versionConflictToken,omitempty"`
 
 	// LastModifierIdentity is the identity of the client that most recently modified the worker deployment.
 	// +optional

--- a/helm/temporal-worker-controller/templates/crds/temporal.io_temporalworkerdeployments.yaml
+++ b/helm/temporal-worker-controller/templates/crds/temporal.io_temporalworkerdeployments.yaml
@@ -3988,9 +3988,7 @@ spec:
                 format: byte
                 type: string
             required:
-            - currentVersion
             - targetVersion
-            - versionConflictToken
             type: object
         type: object
     served: true


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
- WISOTT

## Why?
<!-- Tell your future self why have you made these changes -->
- When someone deploys a TWD initially, `current version` is `nil` and so is `VersionConflictToken`. This is considered fine. 

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
