### PR TITLE
fix variable shadowing error while storing expiry time

### DIFF
--- a/internal/controller/clientpool/clientpool.go
+++ b/internal/controller/clientpool/clientpool.go
@@ -108,6 +108,7 @@ func (cp *ClientPool) UpsertClient(ctx context.Context, opts NewClientOptions) (
 
 	var pemCert []byte
 	var expiryTime time.Time
+	var err error
 
 	// Get the connection secret if it exists
 	if opts.Spec.MutualTLSSecret != "" {
@@ -127,7 +128,7 @@ func (cp *ClientPool) UpsertClient(ctx context.Context, opts NewClientOptions) (
 		pemCert = secret.Data["tls.crt"]
 
 		// Check if certificate is expired before creating the client
-		expiryTime, err := calculateCertificateExpirationTime(pemCert, 5*time.Minute)
+		expiryTime, err = calculateCertificateExpirationTime(pemCert, 5*time.Minute)
 		if err != nil {
 			return nil, fmt.Errorf("failed to check certificate expiration: %v", err)
 		}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
- WISOTT

## Why?
<!-- Tell your future self why have you made these changes -->
- Invalid expiry times were being stored in the client map leading to the controller always parsing the secret.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
