### PR TITLE
Wait for at least last step duration

### DIFF
--- a/api/v1alpha1/make.go
+++ b/api/v1alpha1/make.go
@@ -70,3 +70,7 @@ func MakeTWDWithName(name string) *TemporalWorkerDeployment {
 	twd.Name = name
 	return twd
 }
+
+func ModifyObj[T any](twd T, callback func(obj T) T) T {
+	return callback(twd)
+}

--- a/api/v1alpha1/temporalworker_webhook.go
+++ b/api/v1alpha1/temporalworker_webhook.go
@@ -73,16 +73,20 @@ func (r *TemporalWorkerDeployment) validateForUpdateOrCreate(ctx context.Context
 		return nil, apierrors.NewBadRequest("expected a TemporalWorkerDeployment")
 	}
 
+	return validateForUpdateOrCreate(nil, dep)
+}
+
+func validateForUpdateOrCreate(old, new *TemporalWorkerDeployment) (admission.Warnings, error) {
 	var allErrs field.ErrorList
 
-	if len(dep.GetName()) > maxTemporalWorkerDeploymentNameLen {
+	if len(new.GetName()) > maxTemporalWorkerDeploymentNameLen {
 		allErrs = append(allErrs,
-			field.Invalid(field.NewPath("metadata.name"), dep.Name, fmt.Sprintf("cannot be more than %d characters", maxTemporalWorkerDeploymentNameLen)),
+			field.Invalid(field.NewPath("metadata.name"), new.GetName(), fmt.Sprintf("cannot be more than %d characters", maxTemporalWorkerDeploymentNameLen)),
 		)
 	}
 
-	if dep.Spec.RolloutStrategy.Strategy == UpdateProgressive {
-		rolloutSteps := dep.Spec.RolloutStrategy.Steps
+	if new.Spec.RolloutStrategy.Strategy == UpdateProgressive {
+		rolloutSteps := new.Spec.RolloutStrategy.Steps
 		if len(rolloutSteps) == 0 {
 			allErrs = append(allErrs,
 				field.Invalid(field.NewPath("spec.cutover.steps"), rolloutSteps, "steps are required for Progressive cutover"),
@@ -108,7 +112,7 @@ func (r *TemporalWorkerDeployment) validateForUpdateOrCreate(ctx context.Context
 	}
 
 	if len(allErrs) > 0 {
-		return nil, newInvalidErr(dep, allErrs)
+		return nil, newInvalidErr(new, allErrs)
 	}
 
 	return nil, nil

--- a/api/v1alpha1/worker_types.go
+++ b/api/v1alpha1/worker_types.go
@@ -118,6 +118,10 @@ type TemporalWorkerDeploymentStatus struct {
 	// TargetVersion has been promoted to the current version, this should be nil.
 	RampingVersion *TargetWorkerDeploymentVersion `json:"rampingVersion,omitempty"`
 
+	// RampLastModifiedAt is the time when the ramp percentage was last changed.
+	// +optional
+	RampLastModifiedAt *metav1.Time `json:"rampLastModifiedAt,omitempty"`
+
 	// DeprecatedVersions are deployment versions that are no longer the default. Any
 	// deployment versions that are unreachable should be deleted by the controller.
 	DeprecatedVersions []*DeprecatedWorkerDeploymentVersion `json:"deprecatedVersions,omitempty"`

--- a/helm/temporal-worker-controller/templates/crds/temporal.io_temporalworkerdeployments.yaml
+++ b/helm/temporal-worker-controller/templates/crds/temporal.io_temporalworkerdeployments.yaml
@@ -3854,6 +3854,9 @@ spec:
                 type: array
               lastModifierIdentity:
                 type: string
+              rampLastModifiedAt:
+                format: date-time
+                type: string
               rampingVersion:
                 properties:
                   deployment:

--- a/internal/controller/state_mapper.go
+++ b/internal/controller/state_mapper.go
@@ -41,6 +41,7 @@ func (m *stateMapper) mapToStatus(targetVersionID string) *v1alpha1.TemporalWork
 	status.TargetVersion = m.mapTargetWorkerDeploymentVersion(targetVersionID)
 	if status.TargetVersion != nil && m.temporalState.RampingVersionID == targetVersionID {
 		status.TargetVersion.RampingSince = m.temporalState.RampingSince
+		status.RampLastModifiedAt = m.temporalState.RampLastModifiedAt
 		rampPercentage := m.temporalState.RampPercentage
 		status.TargetVersion.RampPercentage = &rampPercentage
 	}

--- a/internal/k8s/deployments_test.go
+++ b/internal/k8s/deployments_test.go
@@ -21,6 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	temporaliov1alpha1 "github.com/temporalio/temporal-worker-controller/api/v1alpha1"
+	"github.com/temporalio/temporal-worker-controller/internal/testhelpers"
 )
 
 func TestIsDeploymentHealthy(t *testing.T) {
@@ -218,11 +219,11 @@ func TestGenerateBuildID(t *testing.T) {
 			name: "same image different pod specs",
 			generateInputs: func() (*temporaliov1alpha1.TemporalWorkerDeployment, *temporaliov1alpha1.TemporalWorkerDeployment) {
 				img := "my.test_image"
-				pod1 := temporaliov1alpha1.MakePodSpec([]v1.Container{{Image: img}}, map[string]string{"pod": "1"})
-				pod2 := temporaliov1alpha1.MakePodSpec([]v1.Container{{Image: img}}, map[string]string{"pod": "2"})
+				pod1 := testhelpers.MakePodSpec([]v1.Container{{Image: img}}, map[string]string{"pod": "1"})
+				pod2 := testhelpers.MakePodSpec([]v1.Container{{Image: img}}, map[string]string{"pod": "2"})
 
-				twd1 := temporaliov1alpha1.MakeTWD(1, pod1, nil, nil, nil)
-				twd2 := temporaliov1alpha1.MakeTWD(1, pod2, nil, nil, nil)
+				twd1 := testhelpers.MakeTWD(1, pod1, nil, nil, nil)
+				twd2 := testhelpers.MakeTWD(1, pod2, nil, nil, nil)
 				return twd1, twd2
 			},
 			expectedPrefix:  "my-test-image",
@@ -233,10 +234,10 @@ func TestGenerateBuildID(t *testing.T) {
 			name: "same pod specs different TWD spec",
 			generateInputs: func() (*temporaliov1alpha1.TemporalWorkerDeployment, *temporaliov1alpha1.TemporalWorkerDeployment) {
 				img := "my.test_image"
-				pod := temporaliov1alpha1.MakePodSpec([]v1.Container{{Image: img}}, nil)
+				pod := testhelpers.MakePodSpec([]v1.Container{{Image: img}}, nil)
 
-				twd1 := temporaliov1alpha1.MakeTWD(1, pod, nil, nil, nil)
-				twd2 := temporaliov1alpha1.MakeTWD(2, pod, nil, nil, nil)
+				twd1 := testhelpers.MakeTWD(1, pod, nil, nil, nil)
+				twd2 := testhelpers.MakeTWD(2, pod, nil, nil, nil)
 				return twd1, twd2
 			},
 			expectedPrefix:  "my-test-image",
@@ -246,7 +247,7 @@ func TestGenerateBuildID(t *testing.T) {
 		{
 			name: "no containers",
 			generateInputs: func() (*temporaliov1alpha1.TemporalWorkerDeployment, *temporaliov1alpha1.TemporalWorkerDeployment) {
-				twd := temporaliov1alpha1.MakeTWD(1, temporaliov1alpha1.MakePodSpec(nil, nil), nil, nil, nil)
+				twd := testhelpers.MakeTWD(1, testhelpers.MakePodSpec(nil, nil), nil, nil, nil)
 				return twd, nil // only check 1 result, no need to compare
 			},
 			expectedPrefix:  "",
@@ -256,7 +257,7 @@ func TestGenerateBuildID(t *testing.T) {
 		{
 			name: "empty image",
 			generateInputs: func() (*temporaliov1alpha1.TemporalWorkerDeployment, *temporaliov1alpha1.TemporalWorkerDeployment) {
-				twd := temporaliov1alpha1.MakeTWDWithImage("")
+				twd := testhelpers.MakeTWDWithImage("")
 				return twd, nil // only check 1 result, no need to compare
 			},
 			expectedPrefix:  "",
@@ -267,7 +268,7 @@ func TestGenerateBuildID(t *testing.T) {
 			name: "tagged digest image",
 			generateInputs: func() (*temporaliov1alpha1.TemporalWorkerDeployment, *temporaliov1alpha1.TemporalWorkerDeployment) {
 				taggedDigestImg := "docker.io/library/busybox:latest@sha256:" + digest
-				twd := temporaliov1alpha1.MakeTWDWithImage(taggedDigestImg)
+				twd := testhelpers.MakeTWDWithImage(taggedDigestImg)
 				return twd, nil // only check 1 result, no need to compare
 			},
 			expectedPrefix:  "latest",
@@ -278,7 +279,7 @@ func TestGenerateBuildID(t *testing.T) {
 			name: "tagged named image",
 			generateInputs: func() (*temporaliov1alpha1.TemporalWorkerDeployment, *temporaliov1alpha1.TemporalWorkerDeployment) {
 				taggedNamedImg := "docker.io/library/busybox:latest"
-				twd := temporaliov1alpha1.MakeTWDWithImage(taggedNamedImg)
+				twd := testhelpers.MakeTWDWithImage(taggedNamedImg)
 				return twd, nil // only check 1 result, no need to compare
 			},
 			expectedPrefix:  "latest",
@@ -289,7 +290,7 @@ func TestGenerateBuildID(t *testing.T) {
 			name: "digested image",
 			generateInputs: func() (*temporaliov1alpha1.TemporalWorkerDeployment, *temporaliov1alpha1.TemporalWorkerDeployment) {
 				digestedImg := "docker.io@sha256:" + digest
-				twd := temporaliov1alpha1.MakeTWDWithImage(digestedImg)
+				twd := testhelpers.MakeTWDWithImage(digestedImg)
 				return twd, nil // only check 1 result, no need to compare
 			},
 			expectedPrefix:  digest[:maxBuildIdLen-5],
@@ -300,7 +301,7 @@ func TestGenerateBuildID(t *testing.T) {
 			name: "digested named image",
 			generateInputs: func() (*temporaliov1alpha1.TemporalWorkerDeployment, *temporaliov1alpha1.TemporalWorkerDeployment) {
 				digestedNamedImg := "docker.io/library/busybo@sha256:" + digest
-				twd := temporaliov1alpha1.MakeTWDWithImage(digestedNamedImg)
+				twd := testhelpers.MakeTWDWithImage(digestedNamedImg)
 				return twd, nil // only check 1 result, no need to compare
 			},
 			expectedPrefix:  digest[:maxBuildIdLen-5],
@@ -311,7 +312,7 @@ func TestGenerateBuildID(t *testing.T) {
 			name: "named image",
 			generateInputs: func() (*temporaliov1alpha1.TemporalWorkerDeployment, *temporaliov1alpha1.TemporalWorkerDeployment) {
 				namedImg := "docker.io/library/busybox"
-				twd := temporaliov1alpha1.MakeTWDWithImage(namedImg)
+				twd := testhelpers.MakeTWDWithImage(namedImg)
 				return twd, nil // only check 1 result, no need to compare
 			},
 			expectedPrefix:  "library-busybox",
@@ -322,7 +323,7 @@ func TestGenerateBuildID(t *testing.T) {
 			name: "illegal chars image",
 			generateInputs: func() (*temporaliov1alpha1.TemporalWorkerDeployment, *temporaliov1alpha1.TemporalWorkerDeployment) {
 				illegalCharsImg := "this.is.my_weird/image"
-				twd := temporaliov1alpha1.MakeTWDWithImage(illegalCharsImg)
+				twd := testhelpers.MakeTWDWithImage(illegalCharsImg)
 				return twd, nil // only check 1 result, no need to compare
 			},
 			expectedPrefix:  "this-is-my-weird-image",
@@ -333,7 +334,7 @@ func TestGenerateBuildID(t *testing.T) {
 			name: "long image",
 			generateInputs: func() (*temporaliov1alpha1.TemporalWorkerDeployment, *temporaliov1alpha1.TemporalWorkerDeployment) {
 				longImg := "ThisIsAVeryLongHumanReadableImage_ThisIsAVeryLongHumanReadableImage_ThisIsAVeryLongHumanReadableImage" // 101 chars
-				twd := temporaliov1alpha1.MakeTWDWithImage(longImg)
+				twd := testhelpers.MakeTWDWithImage(longImg)
 				return twd, nil // only check 1 result, no need to compare
 			},
 			expectedPrefix:  cleanAndTruncateString("ThisIsAVeryLongHumanReadableImage_ThisIsAVeryLongHumanReadableImage_ThisIsAVeryLongHumanReadableImage"[:maxBuildIdLen-5], -1),

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -338,39 +339,65 @@ func getVersionConfigDiff(
 		vcfg.SetCurrent = true
 		return vcfg
 	case temporaliov1alpha1.UpdateProgressive:
-		// Determine the correct percentage ramp
-		var (
-			healthyDuration    time.Duration
-			currentRamp        float32
-			totalPauseDuration = healthyDuration
-		)
-		if status.TargetVersion.RampingSince != nil {
-			healthyDuration = time.Since(status.TargetVersion.RampingSince.Time)
-			// TODO(carlydf): Is it important that the version spends x time at each step % ?
-			// Currently, if 1% ramp is set, and then multiple reconcile loops error so the next steps aren't set,
-			// the version could skip straight from 1% to current if the error-ing period > totalPauseDuration
-		}
-		for _, s := range strategy.Steps {
-			if s.RampPercentage != 0 { // TODO(carlydf): Support setting any ramp in [0,100]
-				currentRamp = s.RampPercentage
-			}
-			totalPauseDuration += s.PauseDuration.Duration
-			if healthyDuration < totalPauseDuration {
-				// We're still in this step's pause duration
+		return handleProgressiveRollout(strategy.Steps, time.Now(), status.RampLastModifiedAt, status.TargetVersion.RampPercentage, vcfg)
+	}
 
-				// If this step's ramp percentage is the same as the target version's ramp percentage, do nothing
-				if status.TargetVersion.RampPercentage != nil && currentRamp == *status.TargetVersion.RampPercentage {
-					return nil
-				}
+	return nil
+}
 
-				vcfg.RampPercentage = currentRamp
-				return vcfg
-			}
-		}
-		// We've progressed through all steps; it should now be safe to update the default version
+// handleProgressiveRollout handles the progressive rollout strategy logic
+func handleProgressiveRollout(
+	steps []temporaliov1alpha1.RolloutStep,
+	currentTime time.Time, // avoid calling time.Now() inside function to make it easier to test
+	rampLastModifiedAt *metav1.Time,
+	targetRampPercentage *float32,
+	vcfg *VersionConfig,
+) *VersionConfig {
+	// Set current right away if there are no steps.
+	// This is equivalent to the AllAtOnce cutover strategy.
+	if len(steps) == 0 {
 		vcfg.SetCurrent = true
 		return vcfg
 	}
 
+	// Get the currently active step
+	i := getCurrentStepIndex(steps, targetRampPercentage)
+	currentStep := steps[i]
+
+	// If this is the first step and there is no ramp percentage set, set the ramp percentage to the step's ramp percentage
+	if targetRampPercentage == nil || *targetRampPercentage != currentStep.RampPercentage {
+		vcfg.RampPercentage = currentStep.RampPercentage
+		return vcfg
+	}
+
+	// Move to the next step if it has been long enough since the last update
+	if rampLastModifiedAt.Add(currentStep.PauseDuration.Duration).Before(currentTime) {
+		if i < len(steps)-1 {
+			vcfg.RampPercentage = steps[i+1].RampPercentage
+			return vcfg
+		} else {
+			vcfg.SetCurrent = true
+			return vcfg
+		}
+	}
+
+	// In all other cases, do nothing
 	return nil
+}
+
+func getCurrentStepIndex(steps []temporaliov1alpha1.RolloutStep, targetRampPercentage *float32) int {
+	if targetRampPercentage == nil {
+		return 0
+	}
+
+	var result int
+	for i, s := range steps {
+		// Break if ramp percentage is greater than current (use last index)
+		if s.RampPercentage > *targetRampPercentage {
+			break
+		}
+		result = i
+	}
+
+	return result
 }

--- a/internal/temporal/worker_deployment.go
+++ b/internal/temporal/worker_deployment.go
@@ -36,6 +36,7 @@ type TemporalWorkerState struct {
 	RampPercentage       float32
 	// RampingSince is the time when the current ramping version was set.
 	RampingSince         *metav1.Time
+	RampLastModifiedAt   *metav1.Time
 	Versions             map[string]*VersionInfo
 	LastModifierIdentity string
 }
@@ -79,8 +80,12 @@ func GetWorkerDeploymentState(
 
 	// Set ramping since time if applicable
 	if routingConfig.RampingVersion != "" {
-		rt := metav1.NewTime(routingConfig.RampingVersionChangedTime)
-		state.RampingSince = &rt
+		var (
+			rampingSinceTime   = metav1.NewTime(routingConfig.RampingVersionChangedTime)
+			lastRampUpdateTime = metav1.NewTime(workerDeploymentInfo.RoutingConfig.RampingVersionPercentageChangedTime)
+		)
+		state.RampingSince = &rampingSinceTime
+		state.RampLastModifiedAt = &lastRampUpdateTime
 	}
 
 	// Process each version

--- a/internal/testhelpers/make.go
+++ b/internal/testhelpers/make.go
@@ -1,21 +1,23 @@
-package v1alpha1
+package testhelpers
 
 import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+
+	temporaliov1alpha1 "github.com/temporalio/temporal-worker-controller/api/v1alpha1"
 )
 
 func MakeTWD(
 	replicas int32,
 	podSpec v1.PodTemplateSpec,
-	rolloutStrategy *RolloutStrategy,
-	sunsetStrategy *SunsetStrategy,
-	workerOpts *WorkerOptions,
-) *TemporalWorkerDeployment {
-	r := RolloutStrategy{}
-	s := SunsetStrategy{}
-	w := WorkerOptions{}
+	rolloutStrategy *temporaliov1alpha1.RolloutStrategy,
+	sunsetStrategy *temporaliov1alpha1.SunsetStrategy,
+	workerOpts *temporaliov1alpha1.WorkerOptions,
+) *temporaliov1alpha1.TemporalWorkerDeployment {
+	r := temporaliov1alpha1.RolloutStrategy{}
+	s := temporaliov1alpha1.SunsetStrategy{}
+	w := temporaliov1alpha1.WorkerOptions{}
 	if rolloutStrategy != nil {
 		r = *rolloutStrategy
 	}
@@ -26,7 +28,7 @@ func MakeTWD(
 		w = *workerOpts
 	}
 
-	twd := &TemporalWorkerDeployment{
+	twd := &temporaliov1alpha1.TemporalWorkerDeployment{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "temporal.io/v1alpha1",
 			Kind:       "TemporalWorkerDeployment",
@@ -36,7 +38,7 @@ func MakeTWD(
 			Namespace: "default",
 			UID:       types.UID("test-owner-uid"),
 		},
-		Spec: TemporalWorkerDeploymentSpec{
+		Spec: temporaliov1alpha1.TemporalWorkerDeploymentSpec{
 			Replicas:        &replicas,
 			Template:        podSpec,
 			RolloutStrategy: r,
@@ -60,11 +62,11 @@ func MakePodSpec(containers []v1.Container, labels map[string]string) v1.PodTemp
 	}
 }
 
-func MakeTWDWithImage(imageName string) *TemporalWorkerDeployment {
+func MakeTWDWithImage(imageName string) *temporaliov1alpha1.TemporalWorkerDeployment {
 	return MakeTWD(1, MakePodSpec([]v1.Container{{Image: imageName}}, nil), nil, nil, nil)
 }
 
-func MakeTWDWithName(name string) *TemporalWorkerDeployment {
+func MakeTWDWithName(name string) *temporaliov1alpha1.TemporalWorkerDeployment {
 	twd := MakeTWD(1, MakePodSpec(nil, nil), nil, nil, nil)
 	twd.ObjectMeta.Name = name
 	twd.Name = name

--- a/internal/testlogr/testlogr.go
+++ b/internal/testlogr/testlogr.go
@@ -1,0 +1,58 @@
+package testlogr
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+)
+
+// New creates a logger that writes to test output.
+func New(t testing.TB) logr.Logger {
+	t.Helper()
+	return logr.New(&sink{t, nil})
+}
+
+// TODO(jlegrone): Refactor this after https://github.com/golang/go/issues/59928 is released.
+type sink struct {
+	t             testing.TB
+	keysAndValues []any
+}
+
+func (s *sink) Init(info logr.RuntimeInfo) {
+	// pass
+}
+
+func (s *sink) Enabled(level int) bool {
+	// log everything
+	return true
+}
+
+func (s *sink) Info(level int, msg string, keysAndValues ...any) {
+	s.t.Helper()
+	s.log("INFO", msg, keysAndValues...)
+}
+
+func (s *sink) Error(err error, msg string, keysAndValues ...any) {
+	s.t.Helper()
+	s.log("ERROR", msg+" "+err.Error(), keysAndValues...)
+}
+
+func (s *sink) WithValues(keysAndValues ...any) logr.LogSink {
+	s.t.Helper()
+	return &sink{
+		t:             s.t,
+		keysAndValues: append(s.keysAndValues, keysAndValues...),
+	}
+}
+
+func (s *sink) WithName(name string) logr.LogSink {
+	s.t.Helper()
+	return s
+}
+
+func (s *sink) log(level string, msg string, keysAndValues ...any) {
+	s.t.Helper()
+	args := append([]any{level, msg}, s.keysAndValues...)
+	args = append(args, keysAndValues...)
+	s.t.Log(args...)
+}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
- Refactors progressive rollout logic to resume from the step that is equal to or less than the current ramp value
- Requires that the wait time for each step be >= the time since the last ramp value change
- Adds validation to require at least one step in progressive rollouts
- Adds validation to require step pause duration at least 30s
- Implements a sink for writing controller logs to test output
- Refactors test helpers out of public package

## Why?
<!-- Tell your future self why have you made these changes -->
Closes #25 

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
