### PR TITLE
Handle updates to TemporalConnection

### DIFF
--- a/api/v1alpha1/temporalworker_webhook.go
+++ b/api/v1alpha1/temporalworker_webhook.go
@@ -22,6 +22,7 @@ const (
 	defaultScaledownDelay              = 1 * time.Hour
 	defaultDeleteDelay                 = 24 * time.Hour
 	maxTemporalWorkerDeploymentNameLen = 63
+	ConnectionSpecHashAnnotation       = "temporal.io/connection-spec-hash"
 )
 
 func (r *TemporalWorkerDeployment) SetupWebhookWithManager(mgr ctrl.Manager) error {

--- a/internal/controller/genplan.go
+++ b/internal/controller/genplan.go
@@ -94,6 +94,7 @@ func (r *TemporalWorkerDeploymentReconciler) generatePlan(
 		l,
 		k8sState,
 		plannerConfig,
+		connection,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error generating plan: %w", err)

--- a/internal/controller/worker_controller.go
+++ b/internal/controller/worker_controller.go
@@ -93,6 +93,8 @@ func (r *TemporalWorkerDeploymentReconciler) Reconcile(ctx context.Context, req 
 		return ctrl.Result{}, err
 	}
 
+	// TODO (Shivam): Do we validate TemporalConnection here as well?
+
 	// TODO(jlegrone): Set defaults via webhook rather than manually
 	if err := workerDeploy.Default(ctx, &workerDeploy); err != nil {
 		l.Error(err, "TemporalWorkerDeployment defaulter failed")

--- a/internal/controller/worker_controller.go
+++ b/internal/controller/worker_controller.go
@@ -176,7 +176,6 @@ func (r *TemporalWorkerDeploymentReconciler) Reconcile(ctx context.Context, req 
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *TemporalWorkerDeploymentReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	// creates an index so that we can search for TWD deployments that are indexed by the deployment owner
 	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &appsv1.Deployment{}, deployOwnerKey, func(rawObj client.Object) []string {
 		// grab the job object, extract the owner...
 		deploy := rawObj.(*appsv1.Deployment)
@@ -197,7 +196,6 @@ func (r *TemporalWorkerDeploymentReconciler) SetupWithManager(mgr ctrl.Manager) 
 		return err
 	}
 
-	// Step 1: Watch the TemporalConnection resources as well.
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&temporaliov1alpha1.TemporalWorkerDeployment{}).
 		Owns(&appsv1.Deployment{}).

--- a/internal/k8s/deployments.go
+++ b/internal/k8s/deployments.go
@@ -301,7 +301,6 @@ func NewDeploymentWithOwnerRef(
 	}
 }
 
-// Do we wanna put this in a util file?
 func ComputeConnectionSpecHash(connection temporaliov1alpha1.TemporalConnectionSpec) string {
 	// should not happen
 	if connection.MutualTLSSecret == "" || connection.HostPort == "" {

--- a/internal/k8s/deployments.go
+++ b/internal/k8s/deployments.go
@@ -303,11 +303,16 @@ func NewDeploymentWithOwnerRef(
 
 // Do we wanna put this in a util file?
 func ComputeConnectionSpecHash(connection temporaliov1alpha1.TemporalConnectionSpec) string {
+	// should not happen
+	if connection.MutualTLSSecret == "" || connection.HostPort == "" {
+		return ""
+	}
+
 	hasher := sha256.New()
 
 	// Hash connection spec fields in deterministic order
 	hasher.Write([]byte(connection.HostPort))
 	hasher.Write([]byte(connection.MutualTLSSecret))
 
-	return hex.EncodeToString(hasher.Sum(nil)) // Full 64 characters - no collision risk
+	return hex.EncodeToString(hasher.Sum(nil))
 }

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -237,10 +237,7 @@ func shouldCreateOrUpdateDeployment(
 		if d, exists := k8sState.Deployments[config.TargetVersionID]; exists {
 			// If the deployment already exists, we need to check if the secret hash has changed
 			connectionSpecHash := k8s.ComputeConnectionSpecHash(connection)
-			if connectionSpecHash != d.Spec.Template.Annotations[temporaliov1alpha1.ConnectionSpecHashAnnotation] {
-				return true
-			}
-			return false
+			return connectionSpecHash != d.Spec.Template.Annotations[temporaliov1alpha1.ConnectionSpecHashAnnotation]
 		}
 	}
 

--- a/internal/planner/planner_test.go
+++ b/internal/planner/planner_test.go
@@ -194,7 +194,7 @@ func TestGeneratePlan(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			plan, err := GeneratePlan(logr.Discard(), tc.k8sState, tc.config)
+			plan, err := GeneratePlan(logr.Discard(), tc.k8sState, tc.config, temporaliov1alpha1.TemporalConnectionSpec{}) // TODO (Shivam): Come back to this
 			require.NoError(t, err)
 
 			assert.Equal(t, tc.expectDelete, len(plan.DeleteDeployments), "unexpected number of deletions")
@@ -633,7 +633,7 @@ func TestShouldCreateDeployment(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			creates := shouldCreateDeployment(tc.k8sState, tc.config)
+			creates := shouldCreateOrUpdateDeployment(tc.k8sState, tc.config, temporaliov1alpha1.TemporalConnectionSpec{}) // TODO (Shivam): Come back to this
 			assert.Equal(t, tc.expectCreates, creates, "unexpected create decision")
 		})
 	}
@@ -1603,7 +1603,7 @@ func TestComplexVersionStateScenarios(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			plan, err := GeneratePlan(logr.Discard(), tc.k8sState, tc.config)
+			plan, err := GeneratePlan(logr.Discard(), tc.k8sState, tc.config, temporaliov1alpha1.TemporalConnectionSpec{}) // TODO (Shivam): Come back to this
 			require.NoError(t, err)
 
 			assert.Equal(t, tc.expectDeletes, len(plan.DeleteDeployments), "unexpected number of deletes")


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
- Handle updates to `TemporalConnection`, for TWD's that are associated with one, so that these updates are propagated deployments.
- This was achieved by adding the hashed contents of a `TemporalConnection` as pod annotations. Thus, if a TemporalConnection were to get updated, it would result in new deployments with the updated annotation. The new updated secret would also be mounted so that the workers starting can be started with the latest secrets.
- Fixes #10 

## Why?
<!-- Tell your future self why have you made these changes -->
- Better functionality.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
- Added a new unit test for this.
- Going to add a new integration test for this after Carly's PR gets in.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
