### PR TITLE
Add deployment finalizer

### DIFF
--- a/internal/controller/finalizer_test.go
+++ b/internal/controller/finalizer_test.go
@@ -1,0 +1,242 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2024 Datadog, Inc.
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	temporaliov1alpha1 "github.com/temporalio/temporal-worker-controller/api/v1alpha1"
+	"github.com/temporalio/temporal-worker-controller/internal/testhelpers"
+	"github.com/temporalio/temporal-worker-controller/internal/testhelpers/testlogr"
+)
+
+func TestFinalizerAddition(t *testing.T) {
+	ctx := context.Background()
+
+	// Create a TemporalWorkerDeployment without finalizer using test helpers
+	workerDeploy := testhelpers.ModifyObj(testhelpers.MakeTWDWithName("test-worker"), func(twd *temporaliov1alpha1.TemporalWorkerDeployment) *temporaliov1alpha1.TemporalWorkerDeployment {
+		twd.Spec.WorkerOptions = temporaliov1alpha1.WorkerOptions{
+			TemporalNamespace:  "test-namespace",
+			TemporalConnection: "test-connection",
+		}
+		twd.Spec.Template = corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  "worker",
+						Image: "test-image:latest",
+					},
+				},
+			},
+		}
+		return twd
+	})
+
+	// Create fake client with test helpers
+	client := testhelpers.SetupFakeClient()
+
+	// Create the resource in the fake client
+	err := client.Create(ctx, workerDeploy)
+	if err != nil {
+		t.Fatalf("Failed to create TemporalWorkerDeployment: %v", err)
+	}
+
+	// Create reconciler
+	reconciler := &TemporalWorkerDeploymentReconciler{
+		Client: client,
+		Scheme: testhelpers.SetupTestScheme(),
+	}
+
+	// Verify finalizer is not present initially
+	if controllerutil.ContainsFinalizer(workerDeploy, TemporalWorkerDeploymentFinalizer) {
+		t.Error("Finalizer should not be present initially")
+	}
+
+	// Simulate what happens in the reconcile loop when finalizer needs to be added
+	if !controllerutil.ContainsFinalizer(workerDeploy, TemporalWorkerDeploymentFinalizer) {
+		controllerutil.AddFinalizer(workerDeploy, TemporalWorkerDeploymentFinalizer)
+		err := reconciler.Update(ctx, workerDeploy)
+		if err != nil {
+			t.Fatalf("Failed to add finalizer: %v", err)
+		}
+	}
+
+	// Fetch the updated resource
+	updated := &temporaliov1alpha1.TemporalWorkerDeployment{}
+	err = client.Get(ctx, types.NamespacedName{Name: "test-worker", Namespace: "default"}, updated)
+	if err != nil {
+		t.Fatalf("Failed to fetch updated resource: %v", err)
+	}
+
+	// Verify finalizer was added
+	if !controllerutil.ContainsFinalizer(updated, TemporalWorkerDeploymentFinalizer) {
+		t.Error("Finalizer should be present after update")
+	}
+}
+
+func TestIsOwnedByWorkerDeployment(t *testing.T) {
+	// Create a TemporalWorkerDeployment
+	workerDeploy := &temporaliov1alpha1.TemporalWorkerDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-worker",
+			Namespace: "default",
+			UID:       "worker-uid-123",
+		},
+	}
+
+	// Create a deployment owned by the worker deployment
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-deployment",
+			Namespace: "default",
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: apiGVStr,
+					Kind:       "TemporalWorkerDeployment",
+					Name:       "test-worker",
+					UID:        "worker-uid-123",
+				},
+			},
+		},
+	}
+
+	// Create a deployment not owned by the worker deployment
+	unownedDeployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "unowned-deployment",
+			Namespace: "default",
+		},
+	}
+
+	reconciler := &TemporalWorkerDeploymentReconciler{}
+
+	// Test owned deployment
+	if !reconciler.isOwnedByWorkerDeployment(deployment, workerDeploy) {
+		t.Error("Deployment should be identified as owned by worker deployment")
+	}
+
+	// Test unowned deployment
+	if reconciler.isOwnedByWorkerDeployment(unownedDeployment, workerDeploy) {
+		t.Error("Unowned deployment should not be identified as owned by worker deployment")
+	}
+}
+
+func TestCleanupManagedResources(t *testing.T) {
+	ctx := context.Background()
+
+	// Create a TemporalWorkerDeployment using test helpers
+	workerDeploy := testhelpers.ModifyObj(testhelpers.MakeTWDWithName("test-worker"), func(twd *temporaliov1alpha1.TemporalWorkerDeployment) *temporaliov1alpha1.TemporalWorkerDeployment {
+		twd.UID = "worker-uid-123"
+		return twd
+	})
+
+	// Create a deployment owned by the worker deployment
+	ownedDeployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "owned-deployment",
+			Namespace: "default",
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: apiGVStr,
+					Kind:       "TemporalWorkerDeployment",
+					Name:       "test-worker",
+					UID:        "worker-uid-123",
+				},
+			},
+		},
+	}
+
+	// Create a deployment not owned by the worker deployment
+	unownedDeployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "unowned-deployment",
+			Namespace: "default",
+		},
+	}
+
+	// Create fake client with the deployments using test helpers
+	client := testhelpers.SetupFakeClient(ownedDeployment, unownedDeployment)
+
+	reconciler := &TemporalWorkerDeploymentReconciler{
+		Client: client,
+		Scheme: testhelpers.SetupTestScheme(),
+	}
+
+	// Create a test logger using testlogr
+	logger := testlogr.New(t)
+
+	// Test cleanup - should only delete owned deployments
+	err := reconciler.cleanupManagedResources(ctx, logger, workerDeploy)
+	if err != nil {
+		t.Fatalf("Cleanup should succeed: %v", err)
+	}
+
+	// Verify owned deployment was deleted
+	err = client.Get(ctx, types.NamespacedName{Name: "owned-deployment", Namespace: "default"}, &appsv1.Deployment{})
+	if err == nil {
+		t.Error("Owned deployment should have been deleted")
+	}
+
+	// Verify unowned deployment was not deleted
+	err = client.Get(ctx, types.NamespacedName{Name: "unowned-deployment", Namespace: "default"}, &appsv1.Deployment{})
+	if err != nil {
+		t.Error("Unowned deployment should not have been deleted")
+	}
+}
+
+func TestHandleDeletion(t *testing.T) {
+	ctx := context.Background()
+
+	// Create a TemporalWorkerDeployment with finalizer and deletion timestamp using test helpers
+	now := metav1.Now()
+	workerDeploy := testhelpers.ModifyObj(testhelpers.MakeTWDWithName("test-worker"), func(twd *temporaliov1alpha1.TemporalWorkerDeployment) *temporaliov1alpha1.TemporalWorkerDeployment {
+		twd.UID = "worker-uid-123"
+		twd.DeletionTimestamp = &now
+		twd.Finalizers = []string{TemporalWorkerDeploymentFinalizer}
+		twd.Spec.WorkerOptions = temporaliov1alpha1.WorkerOptions{
+			TemporalNamespace:  "test-namespace",
+			TemporalConnection: "test-connection",
+		}
+		return twd
+	})
+
+	// Create fake client using test helpers
+	client := testhelpers.SetupFakeClient(workerDeploy)
+
+	reconciler := &TemporalWorkerDeploymentReconciler{
+		Client: client,
+		Scheme: testhelpers.SetupTestScheme(),
+	}
+
+	// Create a test logger using testlogr
+	logger := testlogr.New(t)
+
+	// Verify finalizer is present before deletion
+	if !controllerutil.ContainsFinalizer(workerDeploy, TemporalWorkerDeploymentFinalizer) {
+		t.Error("Finalizer should be present before deletion handling")
+	}
+
+	// Test deletion handling
+	result, err := reconciler.handleDeletion(ctx, logger, workerDeploy)
+	if err != nil {
+		t.Fatalf("handleDeletion should succeed: %v", err)
+	}
+
+	if result.Requeue {
+		t.Error("Result should not indicate requeue")
+	}
+
+	// After handleDeletion, the resource should be deleted (finalizer removal allows deletion to proceed)
+	// In a real cluster, the resource would be gone. In the fake client, we can verify it was marked for deletion
+	// by checking if the finalizer was removed (which we can't easily do since the resource is deleted)
+	// Instead, we'll verify that the deletion handling completed without error, which means cleanup was successful
+}

--- a/internal/controller/finalizer_test.go
+++ b/internal/controller/finalizer_test.go
@@ -1,7 +1,3 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
-//
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2024 Datadog, Inc.
-
 package controller
 
 import (

--- a/internal/controller/finalizer_test.go
+++ b/internal/controller/finalizer_test.go
@@ -8,15 +8,14 @@ import (
 	"context"
 	"testing"
 
+	temporaliov1alpha1 "github.com/temporalio/temporal-worker-controller/api/v1alpha1"
+	"github.com/temporalio/temporal-worker-controller/internal/testhelpers"
+	"github.com/temporalio/temporal-worker-controller/internal/testhelpers/testlogr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-
-	temporaliov1alpha1 "github.com/temporalio/temporal-worker-controller/api/v1alpha1"
-	"github.com/temporalio/temporal-worker-controller/internal/testhelpers"
-	"github.com/temporalio/temporal-worker-controller/internal/testhelpers/testlogr"
 )
 
 func TestFinalizerAddition(t *testing.T) {
@@ -231,7 +230,7 @@ func TestHandleDeletion(t *testing.T) {
 		t.Fatalf("handleDeletion should succeed: %v", err)
 	}
 
-	if result.Requeue {
+	if result.RequeueAfter > 0 {
 		t.Error("Result should not indicate requeue")
 	}
 

--- a/internal/controller/finalizer_test.go
+++ b/internal/controller/finalizer_test.go
@@ -54,7 +54,7 @@ func TestFinalizerAddition(t *testing.T) {
 	}
 
 	// Verify finalizer is not present initially
-	if controllerutil.ContainsFinalizer(workerDeploy, TemporalWorkerDeploymentFinalizer) {
+	if controllerutil.ContainsFinalizer(workerDeploy, temporalWorkerDeploymentFinalizer) {
 		t.Error("Finalizer should not be present initially")
 	}
 
@@ -79,7 +79,7 @@ func TestFinalizerAddition(t *testing.T) {
 	}
 
 	// Verify finalizer was added
-	if !controllerutil.ContainsFinalizer(updated, TemporalWorkerDeploymentFinalizer) {
+	if !controllerutil.ContainsFinalizer(updated, temporalWorkerDeploymentFinalizer) {
 		t.Error("Finalizer should be present after update")
 	}
 }
@@ -202,7 +202,7 @@ func TestHandleDeletion(t *testing.T) {
 	workerDeploy := testhelpers.ModifyObj(testhelpers.MakeTWDWithName("test-worker", "default"), func(twd *temporaliov1alpha1.TemporalWorkerDeployment) *temporaliov1alpha1.TemporalWorkerDeployment {
 		twd.UID = "worker-uid-123"
 		twd.DeletionTimestamp = &now
-		twd.Finalizers = []string{TemporalWorkerDeploymentFinalizer}
+		twd.Finalizers = []string{temporalWorkerDeploymentFinalizer}
 		twd.Spec.WorkerOptions = temporaliov1alpha1.WorkerOptions{
 			TemporalNamespace:  "test-namespace",
 			TemporalConnection: "test-connection",
@@ -222,7 +222,7 @@ func TestHandleDeletion(t *testing.T) {
 	logger := testlogr.New(t)
 
 	// Verify finalizer is present before deletion
-	if !controllerutil.ContainsFinalizer(workerDeploy, TemporalWorkerDeploymentFinalizer) {
+	if !controllerutil.ContainsFinalizer(workerDeploy, temporalWorkerDeploymentFinalizer) {
 		t.Error("Finalizer should be present before deletion handling")
 	}
 

--- a/internal/controller/finalizer_test.go
+++ b/internal/controller/finalizer_test.go
@@ -23,7 +23,7 @@ func TestFinalizerAddition(t *testing.T) {
 	ctx := context.Background()
 
 	// Create a TemporalWorkerDeployment without finalizer using test helpers
-	workerDeploy := testhelpers.ModifyObj(testhelpers.MakeTWDWithName("test-worker"), func(twd *temporaliov1alpha1.TemporalWorkerDeployment) *temporaliov1alpha1.TemporalWorkerDeployment {
+	workerDeploy := testhelpers.ModifyObj(testhelpers.MakeTWDWithName("test-worker", "default"), func(twd *temporaliov1alpha1.TemporalWorkerDeployment) *temporaliov1alpha1.TemporalWorkerDeployment {
 		twd.Spec.WorkerOptions = temporaliov1alpha1.WorkerOptions{
 			TemporalNamespace:  "test-namespace",
 			TemporalConnection: "test-connection",
@@ -134,7 +134,7 @@ func TestCleanupManagedResources(t *testing.T) {
 	ctx := context.Background()
 
 	// Create a TemporalWorkerDeployment using test helpers
-	workerDeploy := testhelpers.ModifyObj(testhelpers.MakeTWDWithName("test-worker"), func(twd *temporaliov1alpha1.TemporalWorkerDeployment) *temporaliov1alpha1.TemporalWorkerDeployment {
+	workerDeploy := testhelpers.ModifyObj(testhelpers.MakeTWDWithName("test-worker", "default"), func(twd *temporaliov1alpha1.TemporalWorkerDeployment) *temporaliov1alpha1.TemporalWorkerDeployment {
 		twd.UID = "worker-uid-123"
 		return twd
 	})
@@ -198,7 +198,7 @@ func TestHandleDeletion(t *testing.T) {
 
 	// Create a TemporalWorkerDeployment with finalizer and deletion timestamp using test helpers
 	now := metav1.Now()
-	workerDeploy := testhelpers.ModifyObj(testhelpers.MakeTWDWithName("test-worker"), func(twd *temporaliov1alpha1.TemporalWorkerDeployment) *temporaliov1alpha1.TemporalWorkerDeployment {
+	workerDeploy := testhelpers.ModifyObj(testhelpers.MakeTWDWithName("test-worker", "default"), func(twd *temporaliov1alpha1.TemporalWorkerDeployment) *temporaliov1alpha1.TemporalWorkerDeployment {
 		twd.UID = "worker-uid-123"
 		twd.DeletionTimestamp = &now
 		twd.Finalizers = []string{TemporalWorkerDeploymentFinalizer}

--- a/internal/controller/worker_controller.go
+++ b/internal/controller/worker_controller.go
@@ -37,8 +37,8 @@ const (
 	// TODO(jlegrone): add this everywhere
 	deployOwnerKey = ".metadata.controller"
 	buildIDLabel   = "temporal.io/build-id"
-	// TemporalWorkerDeploymentFinalizer is the finalizer used to ensure proper cleanup of resources
-	TemporalWorkerDeploymentFinalizer = "temporal.io/temporal-worker-deployment-finalizer"
+	// temporalWorkerDeploymentFinalizer is the finalizer used to ensure proper cleanup of resources
+	temporalWorkerDeploymentFinalizer = "temporal.io/temporal-worker-deployment-finalizer"
 
 	// Cleanup timeout and polling constants
 	cleanupTimeout      = 2 * time.Minute
@@ -94,8 +94,8 @@ func (r *TemporalWorkerDeploymentReconciler) Reconcile(ctx context.Context, req 
 	}
 
 	// Add finalizer if it doesn't exist
-	if !controllerutil.ContainsFinalizer(&workerDeploy, TemporalWorkerDeploymentFinalizer) {
-		controllerutil.AddFinalizer(&workerDeploy, TemporalWorkerDeploymentFinalizer)
+	if !controllerutil.ContainsFinalizer(&workerDeploy, temporalWorkerDeploymentFinalizer) {
+		controllerutil.AddFinalizer(&workerDeploy, temporalWorkerDeploymentFinalizer)
 		if err := r.Update(ctx, &workerDeploy); err != nil {
 			l.Error(err, "unable to add finalizer")
 			return ctrl.Result{}, err
@@ -217,7 +217,7 @@ func (r *TemporalWorkerDeploymentReconciler) Reconcile(ctx context.Context, req 
 func (r *TemporalWorkerDeploymentReconciler) handleDeletion(ctx context.Context, l logr.Logger, workerDeploy *temporaliov1alpha1.TemporalWorkerDeployment) (ctrl.Result, error) {
 	l.Info("Handling deletion of TemporalWorkerDeployment")
 
-	if !controllerutil.ContainsFinalizer(workerDeploy, TemporalWorkerDeploymentFinalizer) {
+	if !controllerutil.ContainsFinalizer(workerDeploy, temporalWorkerDeploymentFinalizer) {
 		// Finalizer has already been removed, allow deletion to proceed
 		return ctrl.Result{}, nil
 	}
@@ -229,7 +229,7 @@ func (r *TemporalWorkerDeploymentReconciler) handleDeletion(ctx context.Context,
 	}
 
 	// Remove the finalizer to allow deletion
-	controllerutil.RemoveFinalizer(workerDeploy, TemporalWorkerDeploymentFinalizer)
+	controllerutil.RemoveFinalizer(workerDeploy, temporalWorkerDeploymentFinalizer)
 	if err := r.Update(ctx, workerDeploy); err != nil {
 		l.Error(err, "Failed to remove finalizer")
 		return ctrl.Result{}, err

--- a/internal/k8s/deployments.go
+++ b/internal/k8s/deployments.go
@@ -275,8 +275,8 @@ func NewDeploymentWithOwnerRef(
 				BlockOwnerDeletion: &blockOwnerDeletion,
 				Controller:         nil,
 			}},
-			// TODO(jlegrone): Add finalizer managed by the controller in order to prevent
-			//                 deleting deployments that are still reachable.
+			// Note: Finalizer is managed at the TemporalWorkerDeployment level to ensure
+			//       proper cleanup of all managed resources including deployments.
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: spec.Replicas,

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -459,10 +459,9 @@ func handleProgressiveRollout(
 			if i < len(steps)-1 {
 				vcfg.RampPercentage = steps[i+1].RampPercentage
 				return vcfg
-			} else {
-				vcfg.SetCurrent = true
-				return vcfg
 			}
+			vcfg.SetCurrent = true
+			return vcfg
 		}
 	}
 

--- a/internal/testhelpers/make.go
+++ b/internal/testhelpers/make.go
@@ -7,9 +7,13 @@ import (
 	"github.com/pborman/uuid"
 	temporaliov1alpha1 "github.com/temporalio/temporal-worker-controller/api/v1alpha1"
 	"github.com/temporalio/temporal-worker-controller/internal/k8s"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 const (
@@ -206,4 +210,22 @@ func MakeBaseVersion(namespace, twdName, imageName string, status temporaliov1al
 
 func ModifyObj[T any](obj T, callback func(obj T) T) T {
 	return callback(obj)
+}
+
+// SetupTestScheme creates a runtime scheme with all necessary types registered
+func SetupTestScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	_ = appsv1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+	_ = temporaliov1alpha1.AddToScheme(scheme)
+	return scheme
+}
+
+// SetupFakeClient creates a fake Kubernetes client with the given objects
+func SetupFakeClient(objects ...client.Object) client.Client {
+	scheme := SetupTestScheme()
+	return fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objects...).
+		Build()
 }

--- a/internal/tests/internal/integration_test.go
+++ b/internal/tests/internal/integration_test.go
@@ -44,15 +44,6 @@ func waitForCondition(condition func() bool, timeout, interval time.Duration) bo
 	}
 }
 
-type testEnv struct {
-	k8sClient  client.Client
-	mgr        manager.Manager
-	ts         *temporaltest.TestServer
-	connection *temporaliov1alpha1.TemporalConnection
-	replicas   map[string]int32
-	images     map[string]string
-}
-
 // TestIntegration runs integration tests for the Temporal Worker Controller
 func TestIntegration(t *testing.T) {
 	// Set up test environment


### PR DESCRIPTION
## What was changed

Added a deployment finalizer to prevent accidental deletion of deployment resources that would be unrecoverable for the controller.

## Why?

The Temporal worker controller doesn't persist the original pod template anywhere other than in the live Kubernetes deployment resource. When a deployment is accidentally deleted (e.g., via `kubectl delete deployment`), the controller cannot recreate it since it doesn't have the old version of the pod template saved anywhere else.

This finalizer follows the [Kubernetes finalizers pattern](https://kubernetes.io/docs/concepts/overview/working-with-objects/finalizers/) to ensure controlled deletion and prevent unrecoverable state loss.

## Checklist

1. Closes https://github.com/temporalio/temporal-worker-controller/issues/55

2. How was this tested: New integration test validates finalizer behavior during deployment deletion

3. Any docs updates needed: No documentation updates required - this is an internal implementation detail