### PR TITLE
change default deployment name to `resource_namespace`

### DIFF
--- a/internal/k8s/deployments.go
+++ b/internal/k8s/deployments.go
@@ -24,8 +24,8 @@ const (
 	DeployOwnerKey = ".metadata.controller"
 	// BuildIDLabel is the label that identifies the build ID for a deployment
 	BuildIDLabel             = "temporal.io/build-id"
-	DeploymentNameSeparator  = "/" // TODO(carlydf): change this to "." once the server accepts `.` in deployment names
-	VersionIDSeparator       = "." // TODO(carlydf): change this to ":"
+	DeploymentNameSeparator  = "_"
+	VersionIDSeparator       = "."
 	K8sResourceNameSeparator = "-"
 	MaxBuildIdLen            = 63
 )


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed and Why
We discussed using a `.` in the past, but the server won't be able to support that before the release of the controller. A `/` feels off if the ordering is `resource/namespace` because a resource is a sub-component of a namespace, and `/` implies file-system type hierarchy.

I had a [convo with ChatGPT](https://chatgpt.com/share/e/688bebdf-9e6c-8004-8149-dd742bcc0ae0) comparing some options just for fun, and I agree with it that an underscore separator with resource name followed by namespace name feels like the best option.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
Integration and unit tests

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
