### PR TITLE
Manual patch runbook

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,9 @@ This documentation structure is designed to support various types of technical d
 ### [Limits](limits.md)
 Technical constraints and limitations of the Temporal Worker Controller system, including maximum field lengths and other operational boundaries.
 
+### [Patching](patching.md)
+How to deploy a patch build and move workflows to it without making it the Current/Ramping version of your Worker Deployment.
+
 ---
 
 *Note: This documentation structure is designed to grow with the project.*

--- a/docs/patching.md
+++ b/docs/patching.md
@@ -1,0 +1,25 @@
+# Patching
+
+This is a runbook for how to deploy a patch build and move workflows to it without making it the Current/Ramping version
+of your Worker Deployment.
+
+We plan to support this more natively in future releases, but in the meantime if you want to use the worker controller
+to deploy a patch build of a worker, but you don't want new workflows to go to it (or at least not yet), you can follow
+these instructions.
+
+Let's say workflows pinned to Build ID `my-worker:v1.2.0-dsf7` in Worker Deployment `my-worker/prod` have some bug that 
+you want to fix.
+1. You make your patch code change, and build and push an image named `my-worker:v1.2.1`.
+2. If you were doing trunk-style development, you would normally edit the manifest for `TemporalWorkerDeployment` called
+   `my-worker` and deploy it according to your usual rollout strategy. However, in this case you only want workflows that
+   are stuck on the broken `my-worker:v1.2.0` image to run on your patch version. To do this, you need to edit your manifest
+   to have the `Manual` rollout strategy. This means the controller will create your worker pods but will not promote the
+   build.
+
+
+PROBLEM:
+
+This version will never become Active, so when it is no longer the Target Version, the controller will scale it to zero
+workers, because the drainage status is not set.
+
+One fix for this is that on the server, we could trigger "draining" when a versioning override is set on a workflow...

--- a/docs/patching.md
+++ b/docs/patching.md
@@ -7,7 +7,7 @@ We plan to support this more natively in future releases, but in the meantime if
 to deploy a patch build of a worker, but you don't want new workflows to go to it (or at least not yet), you can follow
 these instructions.
 
-Let's say workflows pinned to Build ID `my-worker:v1.2.0-dsf7` in Worker Deployment `my-worker/prod` have some bug that 
+Let's say workflows pinned to Build ID `v1.2.0-dsf7` in Worker Deployment `my-worker/prod` have some bug that 
 you want to fix.
 1. You make your patch code change, and build and push an image named `my-worker:v1.2.1`.
 2. If you were doing trunk-style development, you would normally edit the manifest for `TemporalWorkerDeployment` called
@@ -15,6 +15,16 @@ you want to fix.
    are stuck on the broken `my-worker:v1.2.0` image to run on your patch version. To do this, you need to edit your manifest
    to have the `Manual` rollout strategy. This means the controller will create your worker pods but will not promote the
    build.
+3. The controller will now create a new Build ID `v1.2.1-4543` based on your image and the hash of the pod spec. It will
+   also create the Deployment needed to run your new worker and the worker will start polling.
+4. Now, to move the broken pinned workflows to your new version, set a batch versioning override:
+```bash
+% temporal workflow update-options \
+  --versioning-override-behavior pinned \
+  --versioning-override-build-id v1.2.1-4543 \
+  --versioning-override-deployment-name my-worker/prod \
+  --query 'TemporalWorkerDeploymentVersion = "my-worker/prod:v1.2.0-dsf7" and TemporalWorkerVersioningBehavior = "Pinned" and Status = "Running"'
+```
 
 
 PROBLEM:


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Runbook on how to deploy a patch version and move workflows to it without making it the Active version of the worker deployment.

## Why?
So that users have this information.
Closes #83 

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
