### PR TITLE
Fix CI workflow to use go-version-file instead of hardcoded Go version

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -17,7 +17,8 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.21'
+        go-version-file: 'go.mod'
+        check-latest: true
         cache: true
         
     - name: Install Temporal CLI
@@ -70,7 +71,8 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.21'
+        go-version-file: 'go.mod'
+        check-latest: true
         cache: true
         
     - name: Download dependencies
@@ -100,11 +102,12 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.21'
+        go-version-file: 'go.mod'
+        check-latest: true
         cache: true
         
     - name: Download dependencies
       run: go mod download
       
     - name: Run go vet
-      run: go vet ./... 
+      run: go vet ./...


### PR DESCRIPTION
- Update GitHub Actions workflow to use go-version-file instead of hardcoded Go 1.21
- Add check-latest: true to ensure latest patch version is used
- Fix formatting issue with missing newline at end of file

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
