### PR TITLE
Check versioned and unversioned pollers in certain cases

### DIFF
--- a/api/v1alpha1/temporalworker_webhook.go
+++ b/api/v1alpha1/temporalworker_webhook.go
@@ -57,9 +57,9 @@ func (s *TemporalWorkerDeploymentSpec) Default(ctx context.Context) error {
 		s.SunsetStrategy.DeleteDelay = &v1.Duration{Duration: defaults.DeleteDelay}
 	}
 
-	if s.MaxVersions == nil {
-		maxVersions := int32(defaults.MaxVersions)
-		s.MaxVersions = &maxVersions
+	if s.MaxVersionsIneligibleForDeletion == nil {
+		maxVersions := int32(defaults.MaxVersionsIneligibleForDeletion)
+		s.MaxVersionsIneligibleForDeletion = &maxVersions
 	}
 
 	return nil

--- a/api/v1alpha1/temporalworker_webhook_test.go
+++ b/api/v1alpha1/temporalworker_webhook_test.go
@@ -159,22 +159,22 @@ func TestTemporalWorkerDeployment_Default(t *testing.T) {
 		obj      runtime.Object
 		expected func(t *testing.T, obj *temporaliov1alpha1.TemporalWorkerDeployment)
 	}{
-		"sets default maxVersions": {
+		"sets default maxVersionsIneligibleForDeletion": {
 			obj: testhelpers.MakeTWDWithName("default-max-versions", ""),
 			expected: func(t *testing.T, obj *temporaliov1alpha1.TemporalWorkerDeployment) {
-				require.NotNil(t, obj.Spec.MaxVersions)
-				assert.Equal(t, int32(75), *obj.Spec.MaxVersions)
+				require.NotNil(t, obj.Spec.MaxVersionsIneligibleForDeletion)
+				assert.Equal(t, int32(75), *obj.Spec.MaxVersionsIneligibleForDeletion)
 			},
 		},
-		"preserves existing maxVersions": {
+		"preserves existing maxVersionsIneligibleForDeletion": {
 			obj: testhelpers.ModifyObj(testhelpers.MakeTWDWithName("preserve-max-versions", ""), func(obj *temporaliov1alpha1.TemporalWorkerDeployment) *temporaliov1alpha1.TemporalWorkerDeployment {
 				maxVersions := int32(100)
-				obj.Spec.MaxVersions = &maxVersions
+				obj.Spec.MaxVersionsIneligibleForDeletion = &maxVersions
 				return obj
 			}),
 			expected: func(t *testing.T, obj *temporaliov1alpha1.TemporalWorkerDeployment) {
-				require.NotNil(t, obj.Spec.MaxVersions)
-				assert.Equal(t, int32(100), *obj.Spec.MaxVersions)
+				require.NotNil(t, obj.Spec.MaxVersionsIneligibleForDeletion)
+				assert.Equal(t, int32(100), *obj.Spec.MaxVersionsIneligibleForDeletion)
 			},
 		},
 		"sets default sunset strategy delays": {

--- a/helm/temporal-worker-controller/templates/crds/temporal.io_temporalworkerdeployments.yaml
+++ b/helm/temporal-worker-controller/templates/crds/temporal.io_temporalworkerdeployments.yaml
@@ -46,7 +46,7 @@ spec:
             type: object
           spec:
             properties:
-              maxVersions:
+              maxVersionsIneligibleForDeletion:
                 format: int32
                 minimum: 1
                 type: integer
@@ -3971,6 +3971,9 @@ spec:
                 format: byte
                 type: string
               versionCount:
+                format: int32
+                type: integer
+              versionCountIneligibleForDeletion:
                 format: int32
                 type: integer
             required:

--- a/internal/controller/genstatus.go
+++ b/internal/controller/genstatus.go
@@ -6,7 +6,6 @@ package controller
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/go-logr/logr"
 	temporaliov1alpha1 "github.com/temporalio/temporal-worker-controller/api/v1alpha1"
@@ -26,21 +25,10 @@ func (r *TemporalWorkerDeploymentReconciler) generateStatus(
 	req ctrl.Request,
 	workerDeploy *temporaliov1alpha1.TemporalWorkerDeployment,
 	temporalState *temporal.TemporalWorkerState,
+	k8sState *k8s.DeploymentState,
 ) (*temporaliov1alpha1.TemporalWorkerDeploymentStatus, error) {
 	workerDeploymentName := k8s.ComputeWorkerDeploymentName(workerDeploy)
 	targetBuildID := k8s.ComputeBuildID(workerDeploy)
-
-	// Fetch Kubernetes deployment state
-	k8sState, err := k8s.GetDeploymentState(
-		ctx,
-		r.Client,
-		req.Namespace,
-		req.Name,
-		workerDeploymentName,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("unable to get Kubernetes deployment state: %w", err)
-	}
 
 	// Fetch test workflow status for the desired version
 	if targetBuildID != temporalState.CurrentBuildID {

--- a/internal/controller/state_mapper.go
+++ b/internal/controller/state_mapper.go
@@ -69,6 +69,15 @@ func (m *stateMapper) mapToStatus(targetBuildID string) *v1alpha1.TemporalWorker
 	// Set version count from temporal state (directly from VersionSummaries via Versions map)
 	status.VersionCount = int32(len(m.temporalState.Versions))
 
+	for _, v := range m.temporalState.Versions {
+		if v.Status != v1alpha1.VersionStatusDrained {
+			status.VersionCountIneligibleForDeletion++
+		} else if !v.NoTaskQueuesHaveVersionedPoller {
+			// if there is or might be a versioned poller, consider it ineligible
+			status.VersionCountIneligibleForDeletion++
+		}
+	}
+
 	return status
 }
 

--- a/internal/defaults/defaults.go
+++ b/internal/defaults/defaults.go
@@ -7,8 +7,8 @@ import "time"
 
 // Default values for TemporalWorkerDeploymentSpec fields
 const (
-	ScaledownDelay    = 1 * time.Hour
-	DeleteDelay       = 24 * time.Hour
-	ServerMaxVersions = 100
-	MaxVersions       = int32(ServerMaxVersions * 0.75)
+	ScaledownDelay                   = 1 * time.Hour
+	DeleteDelay                      = 24 * time.Hour
+	ServerMaxVersions                = 100
+	MaxVersionsIneligibleForDeletion = int32(ServerMaxVersions * 0.75)
 )


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
1. Check unversioned pollers for the target version if the current version is nil and strategy is progressive
2. Check versioned pollers for Drained versions if the controller is not running a k8s Deployment for that version

## Why?
1. So that we can still respect Progressive rollout steps if Current Version is nil and we confirm unversioned pollers for all Target Version task queues
2. So that we can only block rollout of a new version if we have a pathological # of ineligible for delete versions, meaning in most cases, users can rely on the server to delete their old versions.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

3. How was this tested:
Tests coming asap :)

4. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
