### PR TITLE
Sanitize build IDs to match k8s label value requirements

### DIFF
--- a/internal/k8s/deployments_test.go
+++ b/internal/k8s/deployments_test.go
@@ -323,7 +323,7 @@ func TestGenerateBuildID(t *testing.T) {
 				twd := testhelpers.MakeTWDWithImage("", "", namedImg)
 				return twd, nil // only check 1 result, no need to compare
 			},
-			expectedPrefix:  "library/busybox",
+			expectedPrefix:  "library-busybox",
 			expectedHashLen: 4,
 			expectEquality:  false,
 		},
@@ -334,7 +334,7 @@ func TestGenerateBuildID(t *testing.T) {
 				twd := testhelpers.MakeTWDWithImage("", "", illegalCharsImg)
 				return twd, nil // only check 1 result, no need to compare
 			},
-			expectedPrefix:  "this.is.my_weird/image",
+			expectedPrefix:  "this.is.my_weird-image",
 			expectedHashLen: 4,
 			expectEquality:  false,
 		},


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Build IDs are now sanitized in order to match k8s label value requirements.

## Why?
<!-- Tell your future self why have you made these changes -->
This ensures that the value of the label `temporal.io/build-id` applied by the controller to k8s resources can match the build ID registered with Temporal.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

N/A

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

Unit tests updated

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

No