### PR TITLE
pin artifact onto specific arch

### DIFF
--- a/.goreleaser.main.yml
+++ b/.goreleaser.main.yml
@@ -32,7 +32,11 @@ checksum:
 
 # Only build Docker images with 'main' tag
 dockers:
-  - image_templates:
+  - ids:
+      - nix
+    goos: linux
+    goarch: amd64
+    image_templates:
       - "temporalio/temporal-worker-controller:main-amd64"
     dockerfile: Dockerfile.goreleaser
     use: buildx
@@ -49,7 +53,11 @@ dockers:
     extra_files:
       - LICENSE
 
-  - image_templates:
+  - ids:
+      - nix
+    goos: linux
+    goarch: arm64
+    image_templates:
       - "temporalio/temporal-worker-controller:main-arm64"
     dockerfile: Dockerfile.goreleaser
     use: buildx

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -40,7 +40,11 @@ checksum:
   algorithm: sha256
 
 dockers:
-  - image_templates:
+  - ids:
+      - nix
+    goos: linux
+    goarch: amd64
+    image_templates:
       - "temporalio/temporal-worker-controller:{{ .Tag }}-amd64"
       - "temporalio/temporal-worker-controller:v{{ .Major }}.{{ .Minor }}-amd64"
     dockerfile: Dockerfile.goreleaser
@@ -58,7 +62,11 @@ dockers:
     extra_files:
       - LICENSE
 
-  - image_templates:
+  - ids:
+      - nix
+    goos: linux
+    goarch: arm64
+    image_templates:
       - "temporalio/temporal-worker-controller:{{ .Tag }}-arm64"
       - "temporalio/temporal-worker-controller:v{{ .Major }}.{{ .Minor }}-arm64"
     dockerfile: Dockerfile.goreleaser


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
- Pin artifact onto the specific architecture that can support it.

## Why?
- So we don't get exec errors (we are getting them right now)

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
- Not tested yet. I am going to test this one out by first merging to main and then using the newly built image on the running controller in our staging environment.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
