### PR TITLE
Throw error and retry Reconcile if Deployment is NotFound

### DIFF
--- a/internal/temporal/worker_deployment.go
+++ b/internal/temporal/worker_deployment.go
@@ -86,11 +86,6 @@ func GetWorkerDeploymentState(
 	// Describe the worker deployment
 	resp, err := deploymentHandler.Describe(ctx, temporalClient.WorkerDeploymentDescribeOptions{})
 	if err != nil {
-		var notFound *serviceerror.NotFound
-		if errors.As(err, &notFound) {
-			// If deployment not found, return empty state
-			return state, nil
-		}
 		return nil, fmt.Errorf("unable to describe worker deployment %s: %w", workerDeploymentName, err)
 	}
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed?
Return NotFound error as an error instead of catching it and returning an empty TemporalState.

## Why?
Returning an empty TemporalState on NotFound error means that the controller believes versions to be NotRegistered when in fact they are Registered and the NotFound error was temporary. 

The controller will delete the Deployment of any non-target version that is NotRegistered, so incorrectly perceiving a version as NotRegistered is very dangerous!

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
It is very clear what the bug is (based on timestamps and server logs) so we want to get this out without testing, but will follow up with a test tomorrow that ensures Deployment Not Found does NOT result in any Deprecated Versions being scaled down.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
