### PR TITLE
Refactor integration tests so they can be run one at a time in IDE

### DIFF
--- a/internal/tests/internal/integration_test.go
+++ b/internal/tests/internal/integration_test.go
@@ -183,9 +183,9 @@ func TestIntegration(t *testing.T) {
 				WithWaitTime(5*time.Second).
 				WithExpectedStatus(
 					testhelpers.NewStatusBuilder(). // controller won't deploy v5, so it's not registered
-						WithTargetVersion("v5", temporaliov1alpha1.VersionStatusNotRegistered, -1, false, false).
-						WithCurrentVersion("v4", true, false).
-						WithDeprecatedVersions( // drained but has pollers, so ineligible for deletion
+									WithTargetVersion("v5", temporaliov1alpha1.VersionStatusNotRegistered, -1, false, false).
+									WithCurrentVersion("v4", true, false).
+									WithDeprecatedVersions( // drained but has pollers, so ineligible for deletion
 							testhelpers.NewDeprecatedVersionInfo("v0", temporaliov1alpha1.VersionStatusDrained, true, false, true),
 							testhelpers.NewDeprecatedVersionInfo("v1", temporaliov1alpha1.VersionStatusDrained, true, false, true),
 							testhelpers.NewDeprecatedVersionInfo("v2", temporaliov1alpha1.VersionStatusDrained, true, false, true),
@@ -383,9 +383,9 @@ func TestIntegration(t *testing.T) {
 				WithWaitTime(5*time.Second).
 				WithExpectedStatus(
 					testhelpers.NewStatusBuilder(). // controller won't deploy v5, so it's not registered
-						WithTargetVersion("v5", temporaliov1alpha1.VersionStatusNotRegistered, -1, false, false).
-						WithCurrentVersion("v4", true, false).
-						WithDeprecatedVersions( // drained but has pollers, so ineligible for deletion
+									WithTargetVersion("v5", temporaliov1alpha1.VersionStatusNotRegistered, -1, false, false).
+									WithCurrentVersion("v4", true, false).
+									WithDeprecatedVersions( // drained but has pollers, so ineligible for deletion
 							testhelpers.NewDeprecatedVersionInfo("v0", temporaliov1alpha1.VersionStatusDrained, true, false, true),
 							testhelpers.NewDeprecatedVersionInfo("v1", temporaliov1alpha1.VersionStatusDrained, true, false, true),
 							testhelpers.NewDeprecatedVersionInfo("v2", temporaliov1alpha1.VersionStatusDrained, true, false, true),
@@ -610,9 +610,9 @@ func TestIntegration(t *testing.T) {
 				WithWaitTime(5*time.Second).
 				WithExpectedStatus(
 					testhelpers.NewStatusBuilder(). // controller won't deploy v5, so it's not registered
-						WithTargetVersion("v5", temporaliov1alpha1.VersionStatusNotRegistered, -1, false, false).
-						WithCurrentVersion("v4", true, false).
-						WithDeprecatedVersions( // drained but has pollers, so ineligible for deletion
+									WithTargetVersion("v5", temporaliov1alpha1.VersionStatusNotRegistered, -1, false, false).
+									WithCurrentVersion("v4", true, false).
+									WithDeprecatedVersions( // drained but has pollers, so ineligible for deletion
 							testhelpers.NewDeprecatedVersionInfo("v0", temporaliov1alpha1.VersionStatusDrained, true, false, true),
 							testhelpers.NewDeprecatedVersionInfo("v1", temporaliov1alpha1.VersionStatusDrained, true, false, true),
 							testhelpers.NewDeprecatedVersionInfo("v2", temporaliov1alpha1.VersionStatusDrained, true, false, true),


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed and why?
Change from map to a slice of objects with names. GoLand will only put the little green arrow next to individual table tests if Go can know what the test name is before runtime. So this is necessary to be able to run or debug these tests one at a time in the IDE.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
Existing tests run as they did before

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
