### PR TITLE
Use an intermediate environment variable in GHA

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -43,6 +43,8 @@ jobs:
 
       - name: Bump Chart Version
         id: bump_version
+        env:
+          VERSION_BUMP: ${{ inputs.version_bump }}
         run: |
           # Get current version from Chart.yaml
           CURRENT_VERSION=$(grep 'version:' helm/temporal-worker-controller/Chart.yaml | awk '{print $2}')
@@ -55,11 +57,11 @@ jobs:
           PATCH=${VERSION_PARTS[2]}
 
           # Increment version based on input
-          if [[ "${{ inputs.version_bump }}" == "major" ]]; then
+          if [[ "${VERSION_BUMP}" == "major" ]]; then
             MAJOR=$((MAJOR + 1))
             MINOR=0
             PATCH=0
-          elif [[ "${{ inputs.version_bump }}" == "minor" ]]; then
+          elif [[ "${VERSION_BUMP}" == "minor" ]]; then
             MINOR=$((MINOR + 1))
             PATCH=0
           else


### PR DESCRIPTION
## What was changed
Use an intermediate environment variable instead of variable interpolation of untrusted user input

## Why?
Best practice is not to trust user input

## Checklist

1. Closes VLN-399

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
