### PR TITLE
VLN-516: Set explicit permissions for GitHub Actions workflows

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -13,6 +13,9 @@ on:
           - minor
           - major
 
+permissions:
+  contents: read
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -5,6 +5,9 @@ on:
     branches: [ main ]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   skaffold-build:
     name: Test Skaffold Build


### PR DESCRIPTION
## Summary

- `.github/workflows/helm.yml`: Added a workflow-level permissions block limiting the default GITHUB_TOKEN to contents: read since the jobs rely on a GitHub App token for pushes.
- `.github/workflows/test-integration.yml`: Declared workflow-level permissions with contents: read to support checkout while preventing unnecessary token scopes for the integration/unit test jobs.