### PR TITLE
feat(api): add stable build ID override via spec.workerOptions.buildID

### DIFF
--- a/api/v1alpha1/worker_types.go
+++ b/api/v1alpha1/worker_types.go
@@ -27,6 +27,22 @@ type WorkerOptions struct {
 	// The Temporal namespace for the worker to connect to.
 	// +kubebuilder:validation:MinLength=1
 	TemporalNamespace string `json:"temporalNamespace"`
+	// BuildID optionally overrides the auto-generated build ID for this worker deployment.
+	// When set, the controller uses this value instead of computing a build ID from the
+	// pod template hash. This enables rolling updates for non-workflow code changes
+	// (bug fixes, config changes) while preserving the same build ID.
+	//
+	// WARNING: Using a custom build ID requires careful management. If workflow code changes
+	// but BuildID stays the same, pinned workflows may execute on workers running incompatible
+	// code. Only use this when you have a reliable way to compute a hash of your workflow
+	// definitions (e.g., hashing workflow source files in CI/CD).
+	//
+	// When the BuildID is stable but pod template spec changes, the controller triggers
+	// a rolling update instead of creating a new deployment version.
+	// +optional
+	// +kubebuilder:validation:MaxLength=63
+	// +kubebuilder:validation:Pattern=`^[a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?$`
+	BuildID string `json:"buildID,omitempty"`
 }
 
 // TemporalWorkerDeploymentSpec defines the desired state of TemporalWorkerDeployment

--- a/helm/temporal-worker-controller/crds/temporal.io_temporalworkerdeployments.yaml
+++ b/helm/temporal-worker-controller/crds/temporal.io_temporalworkerdeployments.yaml
@@ -64,7 +64,6 @@ spec:
                   gate:
                     properties:
                       input:
-                        type: object
                         x-kubernetes-preserve-unknown-fields: true
                       inputFrom:
                         properties:
@@ -73,25 +72,27 @@ spec:
                               key:
                                 type: string
                               name:
+                                default: ""
                                 type: string
                               optional:
                                 type: boolean
                             required:
                             - key
-                            - name
                             type: object
+                            x-kubernetes-map-type: atomic
                           secretKeyRef:
                             properties:
                               key:
                                 type: string
                               name:
+                                default: ""
                                 type: string
                               optional:
                                 type: boolean
                             required:
                             - key
-                            - name
                             type: object
+                            x-kubernetes-map-type: atomic
                         type: object
                       workflowType:
                         type: string
@@ -3941,6 +3942,10 @@ spec:
                 type: object
               workerOptions:
                 properties:
+                  buildID:
+                    maxLength: 63
+                    pattern: ^[a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?$
+                    type: string
                   connectionRef:
                     properties:
                       name:

--- a/internal/planner/planner_test.go
+++ b/internal/planner/planner_test.go
@@ -2176,6 +2176,154 @@ func TestCheckAndUpdateDeploymentConnectionSpec(t *testing.T) {
 	}
 }
 
+func TestCheckAndUpdateDeploymentPodTemplateSpec(t *testing.T) {
+	tests := []struct {
+		name               string
+		buildID            string
+		existingDeployment *appsv1.Deployment
+		newSpec            *temporaliov1alpha1.TemporalWorkerDeploymentSpec
+		connection         temporaliov1alpha1.TemporalConnectionSpec
+		expectUpdate       bool
+		expectImage        string
+	}{
+		{
+			name:               "non-existing deployment does not result in an update",
+			buildID:            "non-existent",
+			existingDeployment: nil,
+			newSpec:            createWorkerSpecWithBuildID("stable-build-id"),
+			connection:         createDefaultConnectionSpec(),
+			expectUpdate:       false,
+		},
+		{
+			name:    "no update when buildID is not explicitly set (auto-generated buildID)",
+			buildID: "v1",
+			existingDeployment: createDeploymentForDriftTest(1, "v1", "old-image:v1"),
+			newSpec: &temporaliov1alpha1.TemporalWorkerDeploymentSpec{
+				Replicas: int32Ptr(1),
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Name: "worker", Image: "new-image:v2"},
+						},
+					},
+				},
+				WorkerOptions: temporaliov1alpha1.WorkerOptions{
+					TemporalNamespace: "test-namespace",
+					// BuildID not set - means auto-generated
+				},
+			},
+			connection:   createDefaultConnectionSpec(),
+			expectUpdate: false, // No update because BuildID is not explicitly set
+		},
+		{
+			name:    "same image does not trigger update when buildID is set",
+			buildID: "stable-build-id",
+			existingDeployment: createDeploymentForDriftTest(1, "stable-build-id", "my-image:v1"),
+			newSpec: &temporaliov1alpha1.TemporalWorkerDeploymentSpec{
+				Replicas: int32Ptr(1),
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Name: "worker", Image: "my-image:v1"},
+						},
+					},
+				},
+				WorkerOptions: temporaliov1alpha1.WorkerOptions{
+					TemporalNamespace: "test-namespace",
+					BuildID:           "stable-build-id",
+				},
+			},
+			connection:   createDefaultConnectionSpec(),
+			expectUpdate: false, // No update because image is the same
+		},
+		{
+			name:    "different image triggers update when buildID is set",
+			buildID: "stable-build-id",
+			existingDeployment: createDeploymentForDriftTest(1, "stable-build-id", "old-image:v1"),
+			newSpec: &temporaliov1alpha1.TemporalWorkerDeploymentSpec{
+				Replicas: int32Ptr(1),
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Name: "worker", Image: "new-image:v2"},
+						},
+					},
+				},
+				WorkerOptions: temporaliov1alpha1.WorkerOptions{
+					TemporalNamespace: "test-namespace",
+					BuildID:           "stable-build-id",
+				},
+			},
+			connection:   createDefaultConnectionSpec(),
+			expectUpdate: true,
+			expectImage:  "new-image:v2",
+		},
+		{
+			name:    "different replicas triggers update when buildID is set",
+			buildID: "stable-build-id",
+			existingDeployment: createDeploymentForDriftTest(1, "stable-build-id", "my-image:v1"),
+			newSpec: &temporaliov1alpha1.TemporalWorkerDeploymentSpec{
+				Replicas: int32Ptr(3), // Changed from 1 to 3
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Name: "worker", Image: "my-image:v1"},
+						},
+					},
+				},
+				WorkerOptions: temporaliov1alpha1.WorkerOptions{
+					TemporalNamespace: "test-namespace",
+					BuildID:           "stable-build-id",
+				},
+			},
+			connection:   createDefaultConnectionSpec(),
+			expectUpdate: true,
+			expectImage:  "my-image:v1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			k8sState := &k8s.DeploymentState{
+				Deployments: map[string]*appsv1.Deployment{},
+			}
+
+			buildID := tt.buildID
+			if tt.existingDeployment != nil {
+				k8sState.Deployments[buildID] = tt.existingDeployment
+			}
+
+			result := checkAndUpdateDeploymentPodTemplateSpec(buildID, k8sState, tt.newSpec, tt.connection)
+
+			if !tt.expectUpdate {
+				assert.Nil(t, result, "Expected no update, but got deployment")
+				return
+			}
+
+			require.NotNil(t, result, "Expected deployment update, but got nil")
+
+			// Check container image was updated
+			if tt.expectImage != "" {
+				require.Len(t, result.Spec.Template.Spec.Containers, 1, "Should have one container")
+				assert.Equal(t, tt.expectImage, result.Spec.Template.Spec.Containers[0].Image, "Container image should be updated")
+			}
+
+			// Check that controller-injected env vars are present
+			found := false
+			for _, container := range result.Spec.Template.Spec.Containers {
+				for _, env := range container.Env {
+					if env.Name == "TEMPORAL_WORKER_BUILD_ID" {
+						assert.Equal(t, buildID, env.Value, "TEMPORAL_WORKER_BUILD_ID should be set")
+						found = true
+						break
+					}
+				}
+			}
+			assert.True(t, found, "Should find TEMPORAL_WORKER_BUILD_ID environment variable")
+		})
+	}
+}
+
 // Helper function to create a deployment with the specified replicas and the default connection spec hash
 func createDeploymentWithDefaultConnectionSpecHash(replicas int32) *appsv1.Deployment {
 	return &appsv1.Deployment{
@@ -2207,6 +2355,45 @@ func createDeploymentWithExpiredConnectionSpecHash(replicas int32) *appsv1.Deplo
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						k8s.ConnectionSpecHashAnnotation: k8s.ComputeConnectionSpecHash(createOutdatedConnectionSpec()),
+					},
+				},
+			},
+		},
+	}
+}
+
+// Helper function to create a deployment for drift testing
+func createDeploymentForDriftTest(replicas int32, buildID string, image string) *appsv1.Deployment {
+	r := replicas
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-deployment",
+			Labels: map[string]string{
+				k8s.BuildIDLabel: buildID,
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &r,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					k8s.BuildIDLabel: buildID,
+				},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						k8s.ConnectionSpecHashAnnotation: k8s.ComputeConnectionSpecHash(createDefaultConnectionSpec()),
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "worker",
+							Image: image,
+							Env: []corev1.EnvVar{
+								{Name: "TEMPORAL_DEPLOYMENT_NAME", Value: "test/my-worker"},
+							},
+						},
 					},
 				},
 			},
@@ -2272,6 +2459,27 @@ func createDefaultWorkerSpec() *temporaliov1alpha1.TemporalWorkerDeploymentSpec 
 		},
 		WorkerOptions: temporaliov1alpha1.WorkerOptions{
 			TemporalNamespace: "test-namespace",
+		},
+	}
+}
+
+// createWorkerSpecWithBuildID creates a worker spec with an explicit buildID set
+func createWorkerSpecWithBuildID(buildID string) *temporaliov1alpha1.TemporalWorkerDeploymentSpec {
+	return &temporaliov1alpha1.TemporalWorkerDeploymentSpec{
+		Replicas: int32Ptr(1),
+		Template: corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  "worker",
+						Image: "test-image:latest",
+					},
+				},
+			},
+		},
+		WorkerOptions: temporaliov1alpha1.WorkerOptions{
+			TemporalNamespace: "test-namespace",
+			BuildID:           buildID,
 		},
 	}
 }


### PR DESCRIPTION
## Summary

Adds support for user-controlled build IDs via `spec.workerOptions.buildID`, enabling rolling updates for non-workflow code changes while preserving new deployment creation for workflow code changes.

## Problem

With PINNED versioning strategy and long-running workflows, **any** pod spec change (image tag, env vars, resources) generates a new build ID, causing deployment proliferation - potentially 10-15 active deployments running simultaneously, causing resource waste and operational complexity.

## Solution

Allow users to set a stable build ID via `spec.workerOptions.buildID`. When the build ID is stable but pod spec changes, trigger a rolling update instead of creating a new deployment.

## API Changes

New optional field in `WorkerOptions`:

```go
// BuildID optionally overrides the auto-generated build ID for this worker deployment.
// When set, the controller uses this value instead of computing a build ID from the
// pod template hash. This enables rolling updates for non-workflow code changes
// (bug fixes, config changes) while preserving the same build ID.
//
// WARNING: Using a custom build ID requires careful management. If workflow code changes
// but BuildID stays the same, pinned workflows may execute on workers running incompatible
// code. Only use this when you have a reliable way to compute a hash of your workflow
// definitions (e.g., hashing workflow source files in CI/CD).
// +optional
// +kubebuilder:validation:MaxLength=63
// +kubebuilder:validation:Pattern=`^[a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?$`
BuildID string `json:"buildID,omitempty"`
```

## Usage

```yaml
apiVersion: temporal.io/v1alpha1
kind: TemporalWorkerDeployment
metadata:
  name: my-worker
spec:
  workerOptions:
    connectionRef:
      name: my-connection
    temporalNamespace: default
    buildID: "wf-a1b2c3d4"  # Set to your workflow code hash
  template:
    spec:
      containers:
        - name: worker
          image: my-worker:v1.2.3  # Can change without new deployment
```

## Drift Detection

When `spec.workerOptions.buildID` is set, the controller detects spec drift by directly comparing the deployed spec with the desired spec (images, resources, replicas, etc.). This is simple and transparent - no hidden state required.

## Behavior Matrix

| Scenario | Build ID | Result |
|----------|----------|--------|
| No buildID field | Auto-generated from image + hash | Existing behavior |
| BuildID set, first deploy | Uses field value | New deployment |
| BuildID unchanged, spec changed | Same build ID | Rolling update |
| BuildID changed | New build ID | New deployment |

## Test Plan

- [x] Build ID spec field override tests (6 test cases)
- [x] Drift detection with direct spec comparison (5 test cases)
- [x] All existing tests pass
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)