### PR TITLE
Added `/scale` subresource to `TemporalWorkerDeployment` CRD

### DIFF
--- a/api/v1alpha1/worker_types.go
+++ b/api/v1alpha1/worker_types.go
@@ -108,6 +108,17 @@ type TemporalWorkerDeploymentStatus struct {
 	// so it's generally not a good idea to read from the status of the root object.
 	// Instead, you should reconstruct it every run.
 
+	// Replicas is the total number of non-terminated pods targeted by this TemporalWorkerDeployment.
+	// This is used by the /scale subresource to report current replica count to HPA/KEDA.
+	// +optional
+	Replicas int32 `json:"replicas,omitempty"`
+
+	// Selector is the label selector for pods managed by this TemporalWorkerDeployment.
+	// This is used by the /scale subresource to allow HPA/KEDA to discover pods.
+	// Format: "app.kubernetes.io/name=<name>"
+	// +optional
+	Selector string `json:"selector,omitempty"`
+
 	// TargetVersion is the desired next version. If TargetVersion.Deployment is nil,
 	// then the controller should create it. If not nil, the controller should
 	// wait for it to become healthy and then move it to the CurrentVersion.
@@ -348,7 +359,9 @@ type ManualRolloutStrategy struct{}
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.selector
 // +kubebuilder:resource:shortName=twd;twdeployment;tworkerdeployment
+//+kubebuilder:printcolumn:name="Replicas",type="integer",JSONPath=".status.replicas",description="Current replicas"
 //+kubebuilder:printcolumn:name="Current",type="string",JSONPath=".status.currentVersion.buildID",description="Current build ID"
 //+kubebuilder:printcolumn:name="Target",type="string",JSONPath=".status.targetVersion.buildID",description="Target build ID"
 //+kubebuilder:printcolumn:name="Ramp %",type="number",JSONPath=".status.targetVersion.rampPercentage",description="Ramp percentage"

--- a/helm/temporal-worker-controller/crds/temporal.io_temporalworkerdeployments.yaml
+++ b/helm/temporal-worker-controller/crds/temporal.io_temporalworkerdeployments.yaml
@@ -19,6 +19,10 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
+    - description: Current replicas
+      jsonPath: .status.replicas
+      name: Replicas
+      type: integer
     - description: Current build ID
       jsonPath: .status.currentVersion.buildID
       name: Current
@@ -64,7 +68,6 @@ spec:
                   gate:
                     properties:
                       input:
-                        type: object
                         x-kubernetes-preserve-unknown-fields: true
                       inputFrom:
                         properties:
@@ -73,25 +76,27 @@ spec:
                               key:
                                 type: string
                               name:
+                                default: ""
                                 type: string
                               optional:
                                 type: boolean
                             required:
                             - key
-                            - name
                             type: object
+                            x-kubernetes-map-type: atomic
                           secretKeyRef:
                             properties:
                               key:
                                 type: string
                               name:
+                                default: ""
                                 type: string
                               optional:
                                 type: boolean
                             required:
                             - key
-                            - name
                             type: object
+                            x-kubernetes-map-type: atomic
                         type: object
                       workflowType:
                         type: string
@@ -4057,6 +4062,11 @@ spec:
                 type: array
               lastModifierIdentity:
                 type: string
+              replicas:
+                format: int32
+                type: integer
+              selector:
+                type: string
               targetVersion:
                 properties:
                   buildID:
@@ -4141,4 +4151,8 @@ spec:
     served: true
     storage: true
     subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
       status: {}


### PR DESCRIPTION
## Summary

Added support for the `/scale` subresource to `TemporalWorkerDeployment` CRD, enabling KEDA and Kubernetes HPA to directly scale the custom resource.
