### PR TITLE
Helm chart bug Fix: Make sure image has nonRoot   

### DIFF
--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -2,8 +2,6 @@ FROM gcr.io/distroless/static-debian12:nonroot
 
 WORKDIR /app
 
-COPY --chown=nonroot:nonroot temporal-worker-controller /usr/local/bin/temporal-worker-controller
-
-USER nonroot
+COPY --chown=65532:65532 temporal-worker-controller /usr/local/bin/temporal-worker-controller
 
 ENTRYPOINT ["temporal-worker-controller"]


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
- Make sure that the image, during create time, has the right image config so that kubelet can rightly validate against it.
- kubelet could not prove that the string "USER nonroot" is not the root. The following changes do that.

## Why?
- Correctness.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->
#192 
#193 

3. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

4. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
