### PR TITLE
fix: use CA certificate from mTLS secret for server verification

### DIFF
--- a/internal/controller/clientpool/clientpool.go
+++ b/internal/controller/clientpool/clientpool.go
@@ -130,9 +130,22 @@ func (cp *ClientPool) fetchClientUsingMTLSSecret(secret corev1.Secret, opts NewC
 	if err != nil {
 		return nil, err
 	}
-	clientOpts.ConnectionOptions.TLS = &tls.Config{
+	tlsCfg := &tls.Config{
 		Certificates: []tls.Certificate{cert},
 	}
+	// If the secret contains a CA certificate, use it as the trusted root for server
+	// certificate verification. This enables connecting to Temporal servers whose TLS
+	// certificates are signed by private or internal CAs (e.g. cert-manager in a test
+	// cluster). When ca.crt is absent, Go falls back to the system CA bundle, which is
+	// the correct behaviour for Temporal Cloud and other publicly-signed endpoints.
+	if caCert, ok := secret.Data["ca.crt"]; ok && len(caCert) > 0 {
+		rootCAs := x509.NewCertPool()
+		if !rootCAs.AppendCertsFromPEM(caCert) {
+			return nil, errors.New("failed to parse CA certificate from secret")
+		}
+		tlsCfg.RootCAs = rootCAs
+	}
+	clientOpts.ConnectionOptions.TLS = tlsCfg
 	expiryTime = exp
 
 	c, err := sdkclient.Dial(clientOpts)


### PR DESCRIPTION
When connecting to a Temporal server via mTLS, the controller reads tls.crt and tls.key from the referenced Kubernetes secret but does not read ca.crt. This causes the controller to fall back to the system CA bundle for server certificate verification, which fails when the server's TLS certificate is signed by a private or internal CA (e.g. cert-manager in a self-hosted cluster).

This change reads ca.crt from the mTLS secret (when present) and uses it as the trusted root CA pool for server certificate verification. This is fully backward compatible. Secrets created by cert-manager automatically include ca.crt. Temporal Cloud users are unaffected since their server certs are signed by public CAs already in the system bundle.

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->
Closes #158

3. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

4. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
