### PR TITLE
explicitly set controller pod's runAsUser and runAsGroup to 65532 for…

### DIFF
--- a/helm/temporal-worker-controller/templates/manager.yaml
+++ b/helm/temporal-worker-controller/templates/manager.yaml
@@ -51,6 +51,8 @@ spec:
       {{- end }}
       securityContext:
         runAsNonRoot: true
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+        runAsGroup: {{ .Values.securityContext.runAsGroup }}
         {{- if .Values.securityContext.seccompProfile.enabled }}
         seccompProfile:
           type: RuntimeDefault

--- a/helm/temporal-worker-controller/values.yaml
+++ b/helm/temporal-worker-controller/values.yaml
@@ -49,6 +49,8 @@ serviceAccount:
 securityContext:
   seccompProfile:
     enabled: false
+  runAsUser: 65532
+  runAsGroup: 65532
 
 # Default podAntiAffinity uses preferredDuringSchedulingIgnoredDuringExecution to spread manager
 # pods across nodes. For strict HA, switch to requiredDuringSchedulingIgnoredDuringExecution.


### PR DESCRIPTION

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Explicitly set runAsUser and runAsGroup to 65532 in the Helm chart's default security context configuration for the manager container. This ensures Kubernetes can properly validate the non-root user requirement when deploying the controller pod.

## Why?
<!-- Tell your future self why have you made these changes -->

The temporal-worker-controller container image (v1.2.0) uses a non-numeric username (nonroot) in its Dockerfile configuration. When Kubernetes enforces runAsNonRoot: true (via Pod Security Standards or cluster policies), it fails to verify the user is non-root because:

* Kubernetes requires numeric UIDs for validation
* The distroless-based image maps nonroot to UID 65532, but Kubernetes cannot resolve string usernames
* This causes CreateContainerConfigError: container has runAsNonRoot and image has non-numeric user (nonroot), cannot verify user is non-root
* By explicitly declaring runAsUser: 65532 and runAsGroup: 65532 (the standard UID/GID for nonroot in distroless images per [GoogleContainerTools/distroless](https://github.com/GoogleContainerTools/distroless)), we:

* [x] Resolve the container startup failure
* [x]  Maintain security best practices (non-root execution)
* [x]  Align with Kubernetes security validation requirements
* [x]  Avoid requiring cluster-wide policy exceptions

## Checklist
<!--- add/delete as needed --->

### How was this tested:

* Deployed modified Helm chart to Kubernetes cluster with Pod Security Standards enforced
* Verified pod status transitioned from Pending → Running
* Confirmed container execution UID via:
kubectl exec -n temporal-system <pod> -c manager -- id → uid=65532(nonroot) gid=65532(nonroot)
* Validated no regression in kube-rbac-proxy container behavior
* Tested across Kubernetes versions v1.34.2 with containerd runtime


### Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

No.