### PR TITLE
fix: migrate kube-rbac-proxy image from deprecated gcr.io to registry.k8s.io

### DIFF
--- a/helm/temporal-worker-controller/templates/manager.yaml
+++ b/helm/temporal-worker-controller/templates/manager.yaml
@@ -107,7 +107,7 @@ spec:
           capabilities:
             drop:
               - "ALL"
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.1
+        image: registry.k8s.io/kubebuilder/kube-rbac-proxy:v0.14.1
         args:
           - "--secure-listen-address=0.0.0.0:8443"
           - --upstream=http://127.0.0.1:{{ .Values.metrics.port }}/


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Updated the kube-rbac-proxy sidecar image reference in the Helm chart from:
```
gcr.io/kubebuilder/kube-rbac-proxy
```
to:
```
registry.k8s.io/kubebuilder/kube-rbac-proxy
```

## Why?
The gcr.io registry is being discontinued. The kube-rbac-proxy project has officially announced the deprecation of `gcr.io/kubebuilder/kube-rbac-proxy` in favour of `registry.k8s.io` — the community-maintained Kubernetes image registry.
Continuing to use the old registry risks image pull failures on new installs or pod restarts once the registry is fully decommissioned, leading to silent deployment breakages.
Ref: https://github.com/kubernetes-sigs/kubebuilder/blob/master/designs/discontinue_usage_of_kube_rbac_proxy.md


## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:

>  - Verified image is pullable from registry.k8s.io/kubebuilder/kube-rbac-proxy
>  - Ran helm template to confirm chart renders correctly with the updated image reference
>  - Deployed to a test cluster and confirmed kube-rbac-proxy sidecar starts successfully

3. Any docs updates needed?
> This is an internal image reference change with no user-facing configuration impact.

 
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
