### PR TITLE
Fix metrics-bind-address binding to localhost when auth proxy is disabled

### DIFF
--- a/helm/temporal-worker-controller/templates/manager.yaml
+++ b/helm/temporal-worker-controller/templates/manager.yaml
@@ -67,7 +67,11 @@ spec:
         args:
         - --leader-elect
         {{- if .Values.metrics.enabled }}
+        {{- if .Values.metrics.disableAuth }}
+        - "--metrics-bind-address=:{{ .Values.metrics.port }}"
+        {{- else }}
         - "--metrics-bind-address=127.0.0.1:{{ .Values.metrics.port }}"
+        {{- end }}
         {{- end }}
         - "--health-probe-bind-address=:8081"
         {{- if .Values.webhook.enabled }}

--- a/helm/temporal-worker-controller/values.yaml
+++ b/helm/temporal-worker-controller/values.yaml
@@ -57,19 +57,42 @@ affinity: {}
 # More than one replica is required for high availability.
 replicas: 2
 
-# Opt out of these resources if you want to disable the
-# auth proxy (https://github.com/brancz/kube-rbac-proxy)
-# which protects your /metrics endpoint.
+# authProxy and metrics.disableAuth together control how /metrics is exposed.
+# They should be set consistently — see the two supported modes below.
+#
+# Mode 1 — Auth-protected metrics (default, recommended for production):
+#   authProxy.enabled: true
+#   metrics.disableAuth: false
+#
+#   A kube-rbac-proxy sidecar (https://github.com/brancz/kube-rbac-proxy) is
+#   injected into the manager pod. It listens on HTTPS port 8443 and proxies to
+#   the manager's metrics endpoint on localhost, authorizing each request via
+#   Kubernetes SubjectAccessReviews. The manager binds metrics to 127.0.0.1 so
+#   it is only reachable through the proxy.
+#
+#   Use this when: running in production, using Prometheus Operator with
+#   ServiceMonitor + RBAC bearer tokens, or in multi-tenant clusters where
+#   metrics should not be freely readable.
+#
+# Mode 2 — Unauthenticated metrics:
+#   authProxy.enabled: false
+#   metrics.disableAuth: true
+#
+#   No proxy sidecar is injected. The manager binds metrics to 0.0.0.0:metrics.port
+#   so Prometheus can scrape it directly without credentials.
+#
+#   Use this when: network-level controls already restrict access (NetworkPolicy,
+#   service mesh, same-namespace Prometheus), your scraper cannot present a
+#   bearer token, or simplicity is preferred (e.g. dev/staging).
 authProxy:
   enabled: true
 
 metrics:
   enabled: true
   port: 8080
-  # Set to true if you want your controller-manager to expose the /metrics
-  # endpoint w/o any authn/z. If false, creates an HTTP proxy sidecar container
-  # for the controller manager which performs RBAC authorization against the
-  # Kubernetes API using SubjectAccessReviews.
+  # See the authProxy comment above for how disableAuth interacts with authProxy.enabled.
+  # When false (default): metrics bind to 127.0.0.1 and are proxied through kube-rbac-proxy.
+  # When true: metrics bind to 0.0.0.0 and are exposed directly without authentication.
   disableAuth: false
 
 namespace:


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed and why
When metrics.disableAuth=true, no kube-rbac-proxy sidecar is injected, so the manager must bind metrics to 0.0.0.0 for Prometheus to scrape them. Previously the address was hardcoded to 127.0.0.1 regardless of this setting.

Also improves values.yaml documentation to explain the two supported modes (auth-protected vs unauthenticated) and how authProxy.enabled and metrics.disableAuth should be set together.

## Checklist
<!--- add/delete as needed --->

1. Closes #167 

2. How was this tested:
Ran `helm template` against both configurations with metrics enabled and confirmed the rendered arg:

disableAuth=true should output --metrics-bind-address=:8080
``` 
helm template test ./helm/temporal-worker-controller \
    --set metrics.enabled=true \
    --set metrics.disableAuth=true \
    | grep metrics-bind-address
```

disableAuth=false should output --metrics-bind-address=127.0.0.1:8080
```  
helm template test ./helm/temporal-worker-controller \
    --set metrics.enabled=true \
    --set metrics.disableAuth=false \
    | grep metrics-bind-address
```

3. Any docs updates needed?
helm values file docs updated.
