### PR TITLE
fix: lowercase CleanStringForDNS output for RFC 1123 compliance

### DIFF
--- a/internal/k8s/deployments.go
+++ b/internal/k8s/deployments.go
@@ -187,7 +187,8 @@ func TruncateString(s string, n int) string {
 func CleanStringForDNS(s string) string {
 	// Keep only letters, numbers, and dashes.
 	re := regexp.MustCompile(`[^a-zA-Z0-9-]+`)
-	return re.ReplaceAllString(s, ResourceNameSeparator)
+	// Lowercase to ensure RFC 1123 DNS label compliance for Kubernetes resource names.
+	return strings.ToLower(re.ReplaceAllString(s, ResourceNameSeparator))
 }
 
 // Build ID is used as a label in k8s, and as the build ID for

--- a/internal/k8s/deployments_test.go
+++ b/internal/k8s/deployments_test.go
@@ -480,6 +480,12 @@ func TestComputeVersionedDeploymentName(t *testing.T) {
 			expectedName: "worker-name-image-v2-1-0-a1b2c3d4",
 		},
 		{
+			name:         "uppercase characters in build ID are lowercased",
+			baseName:     "worker-name",
+			buildID:      "master--HEAD",
+			expectedName: "worker-name-master--head",
+		},
+		{
 			name:         "exceed max length",
 			baseName:     "worker-name-0123456789-0123456789",
 			buildID:      "image-v2.1.0-0123456789-0123456789",


### PR DESCRIPTION
## Summary

`CleanStringForDNS` strips invalid characters but does not lowercase the result. When an image tag contains uppercase characters (e.g. `myimage:master--HEAD`), `ComputeVersionedDeploymentName` produces a deployment name that violates RFC 1123 DNS label rules, causing Kubernetes to reject the Deployment.

This adds `strings.ToLower()` to `CleanStringForDNS` so deployment names are always valid DNS labels.

### Why `CleanStringForDNS` and not `cleanBuildID`?

The build ID is also used as a Kubernetes label value and as the Temporal worker build ID. Labels allow uppercase (`[a-zA-Z0-9._-]`), and Temporal build IDs just need to be ASCII. Lowercasing only in `CleanStringForDNS` keeps the fix scoped to where DNS compliance is required (resource names) without affecting label values or Temporal version matching.