### PR TITLE
fix: clean up Temporal server-side versioning data on TWD deletion

### DIFF
--- a/helm/temporal-worker-controller-crds/templates/temporal.io_temporalworkerdeployments.yaml
+++ b/helm/temporal-worker-controller-crds/templates/temporal.io_temporalworkerdeployments.yaml
@@ -3753,6 +3753,10 @@ spec:
                                             type: integer
                                           signerName:
                                             type: string
+                                          userAnnotations:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
                                         required:
                                         - keyType
                                         - signerName
@@ -3947,6 +3951,18 @@ spec:
                         x-kubernetes-list-map-keys:
                         - name
                         x-kubernetes-list-type: map
+                      workloadRef:
+                        properties:
+                          name:
+                            type: string
+                          podGroup:
+                            type: string
+                          podGroupReplicaKey:
+                            type: string
+                        required:
+                        - name
+                        - podGroup
+                        type: object
                     required:
                     - containers
                     type: object

--- a/helm/temporal-worker-controller/templates/rbac.yaml
+++ b/helm/temporal-worker-controller/templates/rbac.yaml
@@ -110,7 +110,15 @@ rules:
     verbs:
       - get
       - list
+      - patch
+      - update
       - watch
+  - apiGroups:
+      - temporal.io
+    resources:
+      - temporalconnections/finalizers
+    verbs:
+      - update
   - apiGroups:
       - temporal.io
     resources:

--- a/helm/temporal-worker-controller/templates/rbac.yaml
+++ b/helm/temporal-worker-controller/templates/rbac.yaml
@@ -107,6 +107,7 @@ rules:
       - temporal.io
     resources:
       - temporalconnections
+      - workerresourcetemplates
     verbs:
       - get
       - list
@@ -117,6 +118,7 @@ rules:
       - temporal.io
     resources:
       - temporalconnections/finalizers
+      - temporalworkerdeployments/finalizers
     verbs:
       - update
   - apiGroups:
@@ -134,28 +136,12 @@ rules:
   - apiGroups:
       - temporal.io
     resources:
-      - temporalworkerdeployments/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - temporal.io
-    resources:
       - temporalworkerdeployments/status
       - workerresourcetemplates/status
     verbs:
       - get
       - patch
       - update
-  - apiGroups:
-      - temporal.io
-    resources:
-      - workerresourcetemplates
-    verbs:
-      - get
-      - list
-      - patch
-      - update
-      - watch
   # GENERATED RULES END
   # Rules for managing resources attached via WorkerResourceTemplate.
   # Driven entirely by workerResourceTemplate.allowedResources in values.yaml.

--- a/internal/controller/worker_controller.go
+++ b/internal/controller/worker_controller.go
@@ -10,11 +10,13 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/go-logr/logr"
 	temporaliov1alpha1 "github.com/temporalio/temporal-worker-controller/api/v1alpha1"
 	"github.com/temporalio/temporal-worker-controller/internal/controller/clientpool"
 	"github.com/temporalio/temporal-worker-controller/internal/k8s"
 	"github.com/temporalio/temporal-worker-controller/internal/temporal"
 	"go.temporal.io/api/serviceerror"
+	sdkclient "go.temporal.io/sdk/client"
 	"google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
 	appsv1 "k8s.io/api/apps/v1"
@@ -28,6 +30,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -44,6 +47,10 @@ const (
 
 	// wrtWorkerRefKey is the field index key for WorkerResourceTemplate by temporalWorkerDeploymentRef.name.
 	wrtWorkerRefKey = ".spec.temporalWorkerDeploymentRef.name"
+
+	// twdFinalizerName is the finalizer added to TemporalWorkerDeployment resources
+	// to ensure Temporal server-side versioning data is cleaned up before the CRD is deleted.
+	twdFinalizerName = "temporal.io/worker-deployment-cleanup"
 )
 
 // getAPIKeySecretName extracts the secret name from a SecretKeySelector
@@ -137,6 +144,35 @@ func (r *TemporalWorkerDeploymentReconciler) Reconcile(ctx context.Context, req 
 		// the next reconcile fires naturally when the TWD is created. If the List or
 		// status updates fail (transient API errors), return the error to requeue with backoff.
 		return ctrl.Result{}, r.markWRTsTWDNotFound(ctx, req.NamespacedName)
+	}
+
+	// Handle deletion: clean up Temporal server-side versioning data before allowing
+	// the CRD to be deleted. Without this, stale build ID routing persists in Temporal
+	// and prevents unversioned workers from picking up tasks on the same task queue.
+	if !workerDeploy.DeletionTimestamp.IsZero() {
+		if controllerutil.ContainsFinalizer(&workerDeploy, twdFinalizerName) {
+			l.Info("TemporalWorkerDeployment is being deleted, running cleanup")
+			if err := r.handleDeletion(ctx, l, &workerDeploy); err != nil {
+				l.Error(err, "failed to clean up Temporal server-side deployment data")
+				return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+			}
+
+			// Cleanup succeeded, remove the finalizer so K8s can delete the resource
+			controllerutil.RemoveFinalizer(&workerDeploy, twdFinalizerName)
+			if err := r.Update(ctx, &workerDeploy); err != nil {
+				return ctrl.Result{}, err
+			}
+			l.Info("Temporal server-side cleanup complete, finalizer removed")
+		}
+		return ctrl.Result{}, nil
+	}
+
+	// Ensure finalizer is present on non-deleted resources
+	if !controllerutil.ContainsFinalizer(&workerDeploy, twdFinalizerName) {
+		controllerutil.AddFinalizer(&workerDeploy, twdFinalizerName)
+		if err := r.Update(ctx, &workerDeploy); err != nil {
+			return ctrl.Result{}, err
+		}
 	}
 
 	// TODO(jlegrone): Set defaults via webhook rather than manually
@@ -357,6 +393,136 @@ func (r *TemporalWorkerDeploymentReconciler) markWRTsTWDNotFound(ctx context.Con
 		}
 	}
 	return errors.Join(errs...)
+}
+
+// handleDeletion cleans up Temporal server-side deployment versioning data when
+// a TemporalWorkerDeployment CRD is deleted. This prevents stale build ID routing
+// from blocking unversioned workers on the same task queue.
+//
+// The cleanup sequence:
+//  1. Set the current version to "unversioned" (empty BuildID) so new tasks route to unversioned workers
+//  2. Delete all non-current/non-ramping versions (drained/inactive ones)
+//  3. The deployment itself will be garbage collected by Temporal once all versions are removed
+func (r *TemporalWorkerDeploymentReconciler) handleDeletion(
+	ctx context.Context,
+	l logr.Logger,
+	workerDeploy *temporaliov1alpha1.TemporalWorkerDeployment,
+) error {
+	// Resolve Temporal connection
+	var temporalConnection temporaliov1alpha1.TemporalConnection
+	if err := r.Get(ctx, types.NamespacedName{
+		Name:      workerDeploy.Spec.WorkerOptions.TemporalConnectionRef.Name,
+		Namespace: workerDeploy.Namespace,
+	}, &temporalConnection); err != nil {
+		if apierrors.IsNotFound(err) {
+			// TemporalConnection already deleted; we can't talk to Temporal.
+			// Log a warning and allow deletion to proceed to avoid blocking forever.
+			l.Info("TemporalConnection not found, skipping Temporal server-side cleanup")
+			return nil
+		}
+		return fmt.Errorf("unable to fetch TemporalConnection: %w", err)
+	}
+
+	authMode, secretName, err := resolveAuthSecretName(&temporalConnection)
+	if err != nil {
+		return fmt.Errorf("unable to resolve auth secret name: %w", err)
+	}
+
+	temporalClient, ok := r.TemporalClientPool.GetSDKClient(clientpool.ClientPoolKey{
+		HostPort:   temporalConnection.Spec.HostPort,
+		Namespace:  workerDeploy.Spec.WorkerOptions.TemporalNamespace,
+		SecretName: secretName,
+		AuthMode:   authMode,
+	})
+	if !ok {
+		clientOpts, key, clientAuth, err := r.TemporalClientPool.ParseClientSecret(ctx, secretName, authMode, clientpool.NewClientOptions{
+			K8sNamespace:      workerDeploy.Namespace,
+			TemporalNamespace: workerDeploy.Spec.WorkerOptions.TemporalNamespace,
+			Spec:              temporalConnection.Spec,
+			Identity:          getControllerIdentity(),
+		})
+		if err != nil {
+			return fmt.Errorf("unable to parse Temporal auth secret: %w", err)
+		}
+		c, err := r.TemporalClientPool.DialAndUpsertClient(*clientOpts, *key, *clientAuth)
+		if err != nil {
+			return fmt.Errorf("unable to create TemporalClient: %w", err)
+		}
+		temporalClient = c
+	}
+
+	workerDeploymentName := k8s.ComputeWorkerDeploymentName(workerDeploy)
+	deploymentHandler := temporalClient.WorkerDeploymentClient().GetHandle(workerDeploymentName)
+
+	// Describe the deployment to get current state
+	resp, err := deploymentHandler.Describe(ctx, sdkclient.WorkerDeploymentDescribeOptions{})
+	if err != nil {
+		var notFound *serviceerror.NotFound
+		if errors.As(err, &notFound) {
+			l.Info("Worker Deployment not found on Temporal server, nothing to clean up")
+			return nil
+		}
+		return fmt.Errorf("unable to describe worker deployment: %w", err)
+	}
+
+	routingConfig := resp.Info.RoutingConfig
+
+	// Step 1: Set current version to unversioned (empty BuildID) so tasks route to unversioned workers.
+	// This is the critical step that unblocks task dispatch.
+	if routingConfig.CurrentVersion != nil {
+		l.Info("Setting current version to unversioned", "previousBuildID", routingConfig.CurrentVersion.BuildID)
+		if _, err := deploymentHandler.SetCurrentVersion(ctx, sdkclient.WorkerDeploymentSetCurrentVersionOptions{
+			BuildID:                 "", // empty = unversioned
+			ConflictToken:           resp.ConflictToken,
+			Identity:                getControllerIdentity(),
+			IgnoreMissingTaskQueues: true,
+		}); err != nil {
+			return fmt.Errorf("unable to set current version to unversioned: %w", err)
+		}
+		l.Info("Successfully set current version to unversioned")
+	} else {
+		l.Info("No current version set, skipping unversioned redirect")
+	}
+
+	// Step 2: If there's a ramping version, clear it.
+	if routingConfig.RampingVersion != nil {
+		l.Info("Clearing ramping version", "buildID", routingConfig.RampingVersion.BuildID)
+		if _, err := deploymentHandler.SetRampingVersion(ctx, sdkclient.WorkerDeploymentSetRampingVersionOptions{
+			BuildID:    "",
+			Percentage: 0,
+			Identity:   getControllerIdentity(),
+		}); err != nil {
+			l.Info("Failed to clear ramping version (may have been cleared by SetCurrentVersion)", "error", err)
+		}
+	}
+
+	// Step 3: Delete versions that are eligible. Versions that are still draining
+	// are force-deleted with SkipDrainage since the TWD is being removed entirely.
+	for _, version := range resp.Info.VersionSummaries {
+		buildID := version.Version.BuildID
+		l.Info("Deleting worker deployment version", "buildID", buildID)
+		if _, err := deploymentHandler.DeleteVersion(ctx, sdkclient.WorkerDeploymentDeleteVersionOptions{
+			BuildID:      buildID,
+			SkipDrainage: true,
+			Identity:     getControllerIdentity(),
+		}); err != nil {
+			// Log but don't fail -- the version may still have pollers or be current.
+			// Temporal will garbage collect it eventually.
+			l.Info("Could not delete version (will be garbage collected)", "buildID", buildID, "error", err)
+		}
+	}
+
+	// Step 4: Attempt to delete the deployment itself. This only succeeds if all versions are gone.
+	l.Info("Attempting to delete worker deployment from Temporal server", "name", workerDeploymentName)
+	if _, err := temporalClient.WorkerDeploymentClient().Delete(ctx, sdkclient.WorkerDeploymentDeleteOptions{
+		Name:     workerDeploymentName,
+		Identity: getControllerIdentity(),
+	}); err != nil {
+		// Non-fatal: deployment will be garbage collected once all versions drain.
+		l.Info("Could not delete worker deployment (will be garbage collected)", "name", workerDeploymentName, "error", err)
+	}
+
+	return nil
 }
 
 // setCondition sets a condition on the TemporalWorkerDeployment status.

--- a/internal/controller/worker_controller.go
+++ b/internal/controller/worker_controller.go
@@ -156,7 +156,7 @@ func (r *TemporalWorkerDeploymentReconciler) Reconcile(ctx context.Context, req 
 		if controllerutil.ContainsFinalizer(&workerDeploy, finalizerName) {
 			l.Info("TemporalWorkerDeployment is being deleted, running cleanup")
 			if err := r.handleDeletion(ctx, l, &workerDeploy); err != nil {
-				l.Error(err, "failed to clean up Temporal server-side deployment data")
+				l.Error(err, "failed to clean up Temporal server-side deployment data, will retry")
 				return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 			}
 
@@ -512,6 +512,9 @@ func (r *TemporalWorkerDeploymentReconciler) handleDeletion(
 
 	// Step 3: Delete versions that are eligible. Versions that are still draining
 	// are force-deleted with SkipDrainage since the TWD is being removed entirely.
+	// If any version fails to delete (e.g. active pollers), return an error so the
+	// reconciler requeues. Pollers disappear once pods terminate and the next
+	// reconciliation will succeed.
 	for _, version := range resp.Info.VersionSummaries {
 		buildID := version.Version.BuildID
 		l.Info("Deleting worker deployment version", "buildID", buildID)
@@ -520,20 +523,17 @@ func (r *TemporalWorkerDeploymentReconciler) handleDeletion(
 			SkipDrainage: true,
 			Identity:     getControllerIdentity(),
 		}); err != nil {
-			// Log but don't fail -- the version may still have pollers or be current.
-			// Temporal will garbage collect it eventually.
-			l.Info("Could not delete version (will be garbage collected)", "buildID", buildID, "error", err)
+			return fmt.Errorf("unable to delete version %s (will retry): %w", buildID, err)
 		}
 	}
 
-	// Step 4: Attempt to delete the deployment itself. This only succeeds if all versions are gone.
+	// Step 4: Delete the deployment itself. This only succeeds if all versions are gone.
 	l.Info("Attempting to delete worker deployment from Temporal server", "name", workerDeploymentName)
 	if _, err := temporalClient.WorkerDeploymentClient().Delete(ctx, sdkclient.WorkerDeploymentDeleteOptions{
 		Name:     workerDeploymentName,
 		Identity: getControllerIdentity(),
 	}); err != nil {
-		// Non-fatal: deployment will be garbage collected once all versions drain.
-		l.Info("Could not delete worker deployment (will be garbage collected)", "name", workerDeploymentName, "error", err)
+		return fmt.Errorf("unable to delete worker deployment %s (will retry): %w", workerDeploymentName, err)
 	}
 
 	return nil

--- a/internal/controller/worker_controller.go
+++ b/internal/controller/worker_controller.go
@@ -491,6 +491,12 @@ func (r *TemporalWorkerDeploymentReconciler) handleDeletion(
 			return fmt.Errorf("unable to clear ramping version: %w", err)
 		}
 		l.Info("Successfully cleared ramping version")
+
+		// Re-describe to get a fresh ConflictToken after the ramping change.
+		resp, err = deploymentHandler.Describe(ctx, sdkclient.WorkerDeploymentDescribeOptions{})
+		if err != nil {
+			return fmt.Errorf("unable to re-describe worker deployment after clearing ramping version: %w", err)
+		}
 	} else {
 		l.Info("No ramping version set, skipping clear ramping version")
 	}

--- a/internal/controller/worker_controller.go
+++ b/internal/controller/worker_controller.go
@@ -415,9 +415,10 @@ func (r *TemporalWorkerDeploymentReconciler) markWRTsTWDNotFound(ctx context.Con
 // from blocking unversioned workers on the same task queue.
 //
 // The cleanup sequence:
-//  1. Set the current version to "unversioned" (empty BuildID) so new tasks route to unversioned workers
-//  2. Delete all non-current/non-ramping versions (drained/inactive ones)
-//  3. The deployment itself will be garbage collected by Temporal once all versions are removed
+//  1. Clear the ramping version (must happen first to avoid a split-traffic window)
+//  2. Set the current version to "unversioned" (empty BuildID) so new tasks route to unversioned workers
+//  3. Delete all registered versions (with SkipDrainage since the TWD is being removed entirely)
+//  4. Delete the deployment record itself once all versions are gone
 func (r *TemporalWorkerDeploymentReconciler) handleDeletion(
 	ctx context.Context,
 	l logr.Logger,

--- a/internal/controller/worker_controller.go
+++ b/internal/controller/worker_controller.go
@@ -509,6 +509,8 @@ func (r *TemporalWorkerDeploymentReconciler) handleDeletion(
 		}); err != nil {
 			l.Info("Failed to clear ramping version (may have been cleared by SetCurrentVersion)", "error", err)
 		}
+	} else {
+		l.Info("No ramping version set, skipping clear ramping version")
 	}
 
 	// Step 3: Delete versions that are eligible. Versions that are still draining

--- a/internal/controller/worker_controller.go
+++ b/internal/controller/worker_controller.go
@@ -162,7 +162,6 @@ func (r *TemporalWorkerDeploymentReconciler) Reconcile(ctx context.Context, req 
 
 			// Remove our finalizer from the TemporalConnection if no other TWDs reference it.
 			if err := r.removeConnectionFinalizerIfUnused(ctx, l, &workerDeploy); err != nil {
-				l.Error(err, "failed to remove finalizer from TemporalConnection")
 				return ctrl.Result{}, err
 			}
 

--- a/internal/controller/worker_controller.go
+++ b/internal/controller/worker_controller.go
@@ -478,7 +478,24 @@ func (r *TemporalWorkerDeploymentReconciler) handleDeletion(
 
 	routingConfig := resp.Info.RoutingConfig
 
-	// Step 1: Set current version to unversioned (empty BuildID) so tasks route to unversioned workers.
+	// Step 1: Clear the ramping version first. This must happen before setting
+	// current to unversioned to avoid a window where traffic is split between
+	// unversioned workers and the ramping version.
+	if routingConfig.RampingVersion != nil {
+		l.Info("Clearing ramping version", "buildID", routingConfig.RampingVersion.BuildID)
+		if _, err := deploymentHandler.SetRampingVersion(ctx, sdkclient.WorkerDeploymentSetRampingVersionOptions{
+			BuildID:    "",
+			Percentage: 0,
+			Identity:   getControllerIdentity(),
+		}); err != nil {
+			return fmt.Errorf("unable to clear ramping version: %w", err)
+		}
+		l.Info("Successfully cleared ramping version")
+	} else {
+		l.Info("No ramping version set, skipping clear ramping version")
+	}
+
+	// Step 2: Set current version to unversioned (empty BuildID) so tasks route to unversioned workers.
 	// This is the critical step that unblocks task dispatch.
 	if routingConfig.CurrentVersion != nil {
 		l.Info("Setting current version to unversioned", "previousBuildID", routingConfig.CurrentVersion.BuildID)
@@ -493,20 +510,6 @@ func (r *TemporalWorkerDeploymentReconciler) handleDeletion(
 		l.Info("Successfully set current version to unversioned")
 	} else {
 		l.Info("No current version set, skipping unversioned redirect")
-	}
-
-	// Step 2: If there's a ramping version, clear it.
-	if routingConfig.RampingVersion != nil {
-		l.Info("Clearing ramping version", "buildID", routingConfig.RampingVersion.BuildID)
-		if _, err := deploymentHandler.SetRampingVersion(ctx, sdkclient.WorkerDeploymentSetRampingVersionOptions{
-			BuildID:    "",
-			Percentage: 0,
-			Identity:   getControllerIdentity(),
-		}); err != nil {
-			l.Info("Failed to clear ramping version (may have been cleared by SetCurrentVersion)", "error", err)
-		}
-	} else {
-		l.Info("No ramping version set, skipping clear ramping version")
 	}
 
 	// Step 3: Delete versions that are eligible. Versions that are still draining

--- a/internal/controller/worker_controller.go
+++ b/internal/controller/worker_controller.go
@@ -51,6 +51,11 @@ const (
 	// twdFinalizerName is the finalizer added to TemporalWorkerDeployment resources
 	// to ensure Temporal server-side versioning data is cleaned up before the CRD is deleted.
 	twdFinalizerName = "temporal.io/worker-deployment-cleanup"
+
+	// tcFinalizerName is the finalizer added to TemporalConnection resources to prevent
+	// them from being deleted while any TemporalWorkerDeployment still references them.
+	// This ensures the connection is available during TWD deletion cleanup.
+	tcFinalizerName = "temporal.io/connection-in-use"
 )
 
 // getAPIKeySecretName extracts the secret name from a SecretKeySelector
@@ -108,7 +113,8 @@ type TemporalWorkerDeploymentReconciler struct {
 // +kubebuilder:rbac:groups=temporal.io,resources=temporalworkerdeployments,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=temporal.io,resources=temporalworkerdeployments/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=temporal.io,resources=temporalworkerdeployments/finalizers,verbs=update
-// +kubebuilder:rbac:groups=temporal.io,resources=temporalconnections,verbs=get;list;watch
+// +kubebuilder:rbac:groups=temporal.io,resources=temporalconnections,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=temporal.io,resources=temporalconnections/finalizers,verbs=update
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps,resources=deployments/scale,verbs=update
@@ -155,6 +161,12 @@ func (r *TemporalWorkerDeploymentReconciler) Reconcile(ctx context.Context, req 
 			if err := r.handleDeletion(ctx, l, &workerDeploy); err != nil {
 				l.Error(err, "failed to clean up Temporal server-side deployment data")
 				return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+			}
+
+			// Remove our finalizer from the TemporalConnection if no other TWDs reference it.
+			if err := r.removeConnectionFinalizerIfUnused(ctx, l, &workerDeploy); err != nil {
+				l.Error(err, "failed to remove finalizer from TemporalConnection")
+				return ctrl.Result{}, err
 			}
 
 			// Cleanup succeeded, remove the finalizer so K8s can delete the resource
@@ -205,6 +217,13 @@ func (r *TemporalWorkerDeploymentReconciler) Reconcile(ctx context.Context, req 
 			temporaliov1alpha1.ReasonTemporalConnectionNotFound,
 			fmt.Sprintf("Unable to fetch TemporalConnection %q: %v", workerDeploy.Spec.WorkerOptions.TemporalConnectionRef.Name, err),
 			fmt.Sprintf("TemporalConnection %q not found: %v", workerDeploy.Spec.WorkerOptions.TemporalConnectionRef.Name, err))
+		return ctrl.Result{}, err
+	}
+
+	// Ensure our finalizer is on the TemporalConnection so it cannot be deleted
+	// while this TWD still references it. This guarantees the connection is available
+	// during TWD deletion cleanup.
+	if err := r.ensureConnectionFinalizer(ctx, l, &temporalConnection); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -408,18 +427,14 @@ func (r *TemporalWorkerDeploymentReconciler) handleDeletion(
 	l logr.Logger,
 	workerDeploy *temporaliov1alpha1.TemporalWorkerDeployment,
 ) error {
-	// Resolve Temporal connection
+	// Resolve Temporal connection.
+	// The TemporalConnection is guaranteed to exist because we hold a finalizer on it
+	// that prevents deletion while any TWD references it.
 	var temporalConnection temporaliov1alpha1.TemporalConnection
 	if err := r.Get(ctx, types.NamespacedName{
 		Name:      workerDeploy.Spec.WorkerOptions.TemporalConnectionRef.Name,
 		Namespace: workerDeploy.Namespace,
 	}, &temporalConnection); err != nil {
-		if apierrors.IsNotFound(err) {
-			// TemporalConnection already deleted; we can't talk to Temporal.
-			// Log a warning and allow deletion to proceed to avoid blocking forever.
-			l.Info("TemporalConnection not found, skipping Temporal server-side cleanup")
-			return nil
-		}
 		return fmt.Errorf("unable to fetch TemporalConnection: %w", err)
 	}
 
@@ -610,6 +625,74 @@ func (r *TemporalWorkerDeploymentReconciler) recordWarningAndSetBlocked(
 		r.setCondition(workerDeploy, temporaliov1alpha1.ConditionTemporalConnectionHealthy, metav1.ConditionFalse, reason, conditionMessage) //nolint:staticcheck // backward compat
 	}
 	_ = r.Status().Update(ctx, workerDeploy)
+}
+
+// ensureConnectionFinalizer adds our finalizer to the TemporalConnection so it
+// cannot be deleted while this TWD still needs it for cleanup.
+func (r *TemporalWorkerDeploymentReconciler) ensureConnectionFinalizer(
+	ctx context.Context,
+	l logr.Logger,
+	tc *temporaliov1alpha1.TemporalConnection,
+) error {
+	if !controllerutil.ContainsFinalizer(tc, tcFinalizerName) {
+		l.Info("Adding finalizer to TemporalConnection", "connection", tc.Name)
+		controllerutil.AddFinalizer(tc, tcFinalizerName)
+		if err := r.Update(ctx, tc); err != nil {
+			return fmt.Errorf("unable to add finalizer to TemporalConnection %q: %w", tc.Name, err)
+		}
+	}
+	return nil
+}
+
+// removeConnectionFinalizerIfUnused removes our finalizer from the TemporalConnection
+// if no other TWDs (besides the one being deleted) still reference it.
+func (r *TemporalWorkerDeploymentReconciler) removeConnectionFinalizerIfUnused(
+	ctx context.Context,
+	l logr.Logger,
+	deletingTWD *temporaliov1alpha1.TemporalWorkerDeployment,
+) error {
+	connectionName := deletingTWD.Spec.WorkerOptions.TemporalConnectionRef.Name
+
+	// List all TWDs in the same namespace
+	var twds temporaliov1alpha1.TemporalWorkerDeploymentList
+	if err := r.List(ctx, &twds, client.InNamespace(deletingTWD.Namespace)); err != nil {
+		return fmt.Errorf("unable to list TWDs: %w", err)
+	}
+
+	// Check if any other TWD (not the one being deleted) references this connection
+	for i := range twds.Items {
+		twd := &twds.Items[i]
+		if twd.Name == deletingTWD.Name {
+			continue
+		}
+		if twd.Spec.WorkerOptions.TemporalConnectionRef.Name == connectionName {
+			l.Info("TemporalConnection still referenced by another TWD, keeping finalizer",
+				"connection", connectionName, "referencedBy", twd.Name)
+			return nil
+		}
+	}
+
+	// No other TWDs reference this connection, remove the finalizer
+	var tc temporaliov1alpha1.TemporalConnection
+	if err := r.Get(ctx, types.NamespacedName{
+		Name:      connectionName,
+		Namespace: deletingTWD.Namespace,
+	}, &tc); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil // already gone
+		}
+		return fmt.Errorf("unable to fetch TemporalConnection %q: %w", connectionName, err)
+	}
+
+	if controllerutil.ContainsFinalizer(&tc, tcFinalizerName) {
+		l.Info("Removing finalizer from TemporalConnection", "connection", connectionName)
+		controllerutil.RemoveFinalizer(&tc, tcFinalizerName)
+		if err := r.Update(ctx, &tc); err != nil {
+			return fmt.Errorf("unable to remove finalizer from TemporalConnection %q: %w", connectionName, err)
+		}
+	}
+
+	return nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/worker_controller.go
+++ b/internal/controller/worker_controller.go
@@ -48,14 +48,11 @@ const (
 	// wrtWorkerRefKey is the field index key for WorkerResourceTemplate by temporalWorkerDeploymentRef.name.
 	wrtWorkerRefKey = ".spec.temporalWorkerDeploymentRef.name"
 
-	// twdFinalizerName is the finalizer added to TemporalWorkerDeployment resources
-	// to ensure Temporal server-side versioning data is cleaned up before the CRD is deleted.
-	twdFinalizerName = "temporal.io/worker-deployment-cleanup"
-
-	// tcFinalizerName is the finalizer added to TemporalConnection resources to prevent
-	// them from being deleted while any TemporalWorkerDeployment still references them.
-	// This ensures the connection is available during TWD deletion cleanup.
-	tcFinalizerName = "temporal.io/connection-in-use"
+	// finalizerName is the finalizer added to TemporalWorkerDeployment and TemporalConnection
+	// resources to prevent deletion before cleanup actions are taken. On TWD resources, it
+	// ensures Temporal server-side versioning data is cleaned up. On TemporalConnection
+	// resources, it prevents deletion while any TWD still references the connection.
+	finalizerName = "temporal.io/delete-protection"
 )
 
 // getAPIKeySecretName extracts the secret name from a SecretKeySelector
@@ -156,7 +153,7 @@ func (r *TemporalWorkerDeploymentReconciler) Reconcile(ctx context.Context, req 
 	// the CRD to be deleted. Without this, stale build ID routing persists in Temporal
 	// and prevents unversioned workers from picking up tasks on the same task queue.
 	if !workerDeploy.DeletionTimestamp.IsZero() {
-		if controllerutil.ContainsFinalizer(&workerDeploy, twdFinalizerName) {
+		if controllerutil.ContainsFinalizer(&workerDeploy, finalizerName) {
 			l.Info("TemporalWorkerDeployment is being deleted, running cleanup")
 			if err := r.handleDeletion(ctx, l, &workerDeploy); err != nil {
 				l.Error(err, "failed to clean up Temporal server-side deployment data")
@@ -170,7 +167,7 @@ func (r *TemporalWorkerDeploymentReconciler) Reconcile(ctx context.Context, req 
 			}
 
 			// Cleanup succeeded, remove the finalizer so K8s can delete the resource
-			controllerutil.RemoveFinalizer(&workerDeploy, twdFinalizerName)
+			controllerutil.RemoveFinalizer(&workerDeploy, finalizerName)
 			if err := r.Update(ctx, &workerDeploy); err != nil {
 				return ctrl.Result{}, err
 			}
@@ -180,8 +177,8 @@ func (r *TemporalWorkerDeploymentReconciler) Reconcile(ctx context.Context, req 
 	}
 
 	// Ensure finalizer is present on non-deleted resources
-	if !controllerutil.ContainsFinalizer(&workerDeploy, twdFinalizerName) {
-		controllerutil.AddFinalizer(&workerDeploy, twdFinalizerName)
+	if !controllerutil.ContainsFinalizer(&workerDeploy, finalizerName) {
+		controllerutil.AddFinalizer(&workerDeploy, finalizerName)
 		if err := r.Update(ctx, &workerDeploy); err != nil {
 			return ctrl.Result{}, err
 		}
@@ -636,9 +633,9 @@ func (r *TemporalWorkerDeploymentReconciler) ensureConnectionFinalizer(
 	l logr.Logger,
 	tc *temporaliov1alpha1.TemporalConnection,
 ) error {
-	if !controllerutil.ContainsFinalizer(tc, tcFinalizerName) {
+	if !controllerutil.ContainsFinalizer(tc, finalizerName) {
 		l.Info("Adding finalizer to TemporalConnection", "connection", tc.Name)
-		controllerutil.AddFinalizer(tc, tcFinalizerName)
+		controllerutil.AddFinalizer(tc, finalizerName)
 		if err := r.Update(ctx, tc); err != nil {
 			return fmt.Errorf("unable to add finalizer to TemporalConnection %q: %w", tc.Name, err)
 		}
@@ -686,9 +683,9 @@ func (r *TemporalWorkerDeploymentReconciler) removeConnectionFinalizerIfUnused(
 		return fmt.Errorf("unable to fetch TemporalConnection %q: %w", connectionName, err)
 	}
 
-	if controllerutil.ContainsFinalizer(&tc, tcFinalizerName) {
+	if controllerutil.ContainsFinalizer(&tc, finalizerName) {
 		l.Info("Removing finalizer from TemporalConnection", "connection", connectionName)
-		controllerutil.RemoveFinalizer(&tc, tcFinalizerName)
+		controllerutil.RemoveFinalizer(&tc, finalizerName)
 		if err := r.Update(ctx, &tc); err != nil {
 			return fmt.Errorf("unable to remove finalizer from TemporalConnection %q: %w", connectionName, err)
 		}

--- a/internal/tests/internal/deletion_integration_test.go
+++ b/internal/tests/internal/deletion_integration_test.go
@@ -123,6 +123,58 @@ func testDeletionSetsCurrentToUnversioned(
 	})
 	t.Log("TWD is reconciled with a current version set")
 
+	// Update the TWD to target v2.0, creating a second version to use as a ramping version.
+	// This exercises the ramping-version clear path in handleDeletion.
+	var twdForUpdate temporaliov1alpha1.TemporalWorkerDeployment
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: twd.Name, Namespace: namespace}, &twdForUpdate); err != nil {
+		t.Fatalf("failed to get TWD for v2.0 update: %v", err)
+	}
+	twdForUpdate.Spec.Template.Spec.Containers[0].Image = "v2.0"
+	buildIDv2 := k8s.ComputeBuildID(&twdForUpdate)
+	deploymentNameV2 := k8s.ComputeVersionedDeploymentName(twd.Name, buildIDv2)
+	if err := k8sClient.Update(ctx, &twdForUpdate); err != nil {
+		t.Fatalf("failed to update TWD to v2.0: %v", err)
+	}
+
+	// Wait for the controller to create the v2.0 K8s Deployment
+	eventually(t, 30*time.Second, time.Second, func() error {
+		var dep appsv1.Deployment
+		return k8sClient.Get(ctx, types.NamespacedName{Name: deploymentNameV2, Namespace: namespace}, &dep)
+	})
+
+	// Start v2.0 workers so they register with the Temporal server
+	workerStopFuncsV2 := applyDeployment(t, ctx, k8sClient, deploymentNameV2, namespace)
+	defer handleStopFuncs(workerStopFuncsV2)
+
+	// Wait for v2.0 to appear as a version in the Temporal deployment
+	eventually(t, 60*time.Second, 2*time.Second, func() error {
+		resp, err := deploymentHandle.Describe(ctx, sdkclient.WorkerDeploymentDescribeOptions{})
+		if err != nil {
+			return err
+		}
+		for _, v := range resp.Info.VersionSummaries {
+			if v.Version.BuildID == buildIDv2 {
+				return nil
+			}
+		}
+		return fmt.Errorf("v2.0 (buildID=%s) not yet visible in Temporal deployment", buildIDv2)
+	})
+
+	// Set v2.0 as the ramping version so we exercise the clear-ramping path on deletion
+	descResp, err := deploymentHandle.Describe(ctx, sdkclient.WorkerDeploymentDescribeOptions{})
+	if err != nil {
+		t.Fatalf("failed to describe deployment before setting ramping version: %v", err)
+	}
+	if _, err := deploymentHandle.SetRampingVersion(ctx, sdkclient.WorkerDeploymentSetRampingVersionOptions{
+		BuildID:       buildIDv2,
+		Percentage:    50,
+		ConflictToken: descResp.ConflictToken,
+		Identity:      "test",
+	}); err != nil {
+		t.Fatalf("failed to set v2.0 as ramping version: %v", err)
+	}
+	t.Logf("Set v2.0 (buildID=%s) as ramping version at 50%%", buildIDv2)
+
 	// Verify the TWD has our finalizer
 	var twdBeforeDelete temporaliov1alpha1.TemporalWorkerDeployment
 	if err := k8sClient.Get(ctx, types.NamespacedName{Name: twd.Name, Namespace: namespace}, &twdBeforeDelete); err != nil {
@@ -172,6 +224,13 @@ func testDeletionSetsCurrentToUnversioned(
 			resp.Info.RoutingConfig.CurrentVersion.BuildID)
 	} else {
 		t.Log("Verified: current version is unversioned after TWD deletion")
+	}
+
+	if resp.Info.RoutingConfig.RampingVersion != nil {
+		t.Errorf("expected ramping version to be nil after TWD deletion, got buildID=%q",
+			resp.Info.RoutingConfig.RampingVersion.BuildID)
+	} else {
+		t.Log("Verified: ramping version is cleared after TWD deletion")
 	}
 }
 

--- a/internal/tests/internal/deletion_integration_test.go
+++ b/internal/tests/internal/deletion_integration_test.go
@@ -172,8 +172,8 @@ func testDeletionSetsCurrentToUnversioned(
 		// v2.0 is already current; revert to v1.0 so we can set v2.0 as ramping.
 		t.Logf("v2.0 is already current; reverting to v1.0 as current before setting v2.0 as ramping")
 		if _, err := deploymentHandle.SetCurrentVersion(ctx, sdkclient.WorkerDeploymentSetCurrentVersionOptions{
-			BuildID:                buildID,
-			ConflictToken:          descResp.ConflictToken,
+			BuildID:                 buildID,
+			ConflictToken:           descResp.ConflictToken,
 			IgnoreMissingTaskQueues: true,
 		}); err != nil {
 			t.Fatalf("failed to revert current version to v1.0: %v", err)

--- a/internal/tests/internal/deletion_integration_test.go
+++ b/internal/tests/internal/deletion_integration_test.go
@@ -58,17 +58,13 @@ func testDeletionSetsCurrentToUnversioned(
 	ctx := context.Background()
 	testName := "del-cleanup"
 
-	// Build a TWD using the standard builder pattern
+	// Use Manual strategy so the controller does not race to promote v2.0 to current
+	// while the test is setting it up as a ramping version.
 	tc := testhelpers.NewTestCase().
 		WithInput(
 			testhelpers.NewTemporalWorkerDeploymentBuilder().
-				WithAllAtOnceStrategy().
+				WithManualStrategy().
 				WithTargetTemplate("v1.0"),
-		).
-		WithExpectedStatus(
-			testhelpers.NewStatusBuilder().
-				WithTargetVersion("v1.0", temporaliov1alpha1.VersionStatusCurrent, -1, true, false).
-				WithCurrentVersion("v1.0", true, false),
 		).
 		BuildWithValues(testName, namespace, ts.GetDefaultNamespace())
 
@@ -109,19 +105,12 @@ func testDeletionSetsCurrentToUnversioned(
 	workerStopFuncs := applyDeployment(t, ctx, k8sClient, expectedDeploymentName, namespace)
 	defer handleStopFuncs(workerStopFuncs)
 
-	// Wait until the version becomes current on the Temporal server
+	// Manual strategy does not auto-promote, so set v1.0 as current explicitly.
+	// setCurrentVersion uses defaults.ControllerIdentity so handleDeletion can later
+	// update versioning state without a ManagerIdentity mismatch.
 	deploymentHandle := ts.GetDefaultClient().WorkerDeploymentClient().GetHandle(workerDeploymentName)
-	eventually(t, 60*time.Second, 2*time.Second, func() error {
-		resp, err := deploymentHandle.Describe(ctx, sdkclient.WorkerDeploymentDescribeOptions{})
-		if err != nil {
-			return err
-		}
-		if resp.Info.RoutingConfig.CurrentVersion == nil {
-			return errors.New("current version not set yet")
-		}
-		return nil
-	})
-	t.Log("TWD is reconciled with a current version set")
+	setCurrentVersion(t, ctx, ts, workerDeploymentName, buildID)
+	t.Log("v1.0 set as current version")
 
 	// Update the TWD to target v2.0, creating a second version to use as a ramping version.
 	// This exercises the ramping-version clear path in handleDeletion.
@@ -160,48 +149,8 @@ func testDeletionSetsCurrentToUnversioned(
 		return fmt.Errorf("v2.0 (buildID=%s) not yet visible in Temporal deployment", buildIDv2)
 	})
 
-	// Create a client matching the controller's ManagerIdentity so we can revert the
-	// current version when the AllAtOnce controller has already promoted v2.0.
-	controllerClient, err := sdkclient.Dial(sdkclient.Options{
-		HostPort:  ts.GetFrontendHostPort(),
-		Namespace: ts.GetDefaultNamespace(),
-		Identity:  "temporal-worker-controller",
-	})
-	if err != nil {
-		t.Fatalf("failed to create controller-identity client: %v", err)
-	}
-	defer controllerClient.Close()
-	controllerHandle := controllerClient.WorkerDeploymentClient().GetHandle(workerDeploymentName)
-
 	// Set v2.0 as the ramping version to exercise the clear-ramping path on deletion.
-	// The AllAtOnce controller races to promote v2.0 to current; retry until we win:
-	// if v2.0 is already current, revert to v1.0 using the controller identity, then retry.
-	eventually(t, 30*time.Second, time.Second, func() error {
-		descResp, err := deploymentHandle.Describe(ctx, sdkclient.WorkerDeploymentDescribeOptions{})
-		if err != nil {
-			return err
-		}
-		if descResp.Info.RoutingConfig.CurrentVersion != nil && descResp.Info.RoutingConfig.CurrentVersion.BuildID == buildIDv2 {
-			t.Logf("v2.0 is already current; reverting to v1.0 before setting v2.0 as ramping")
-			if _, err := controllerHandle.SetCurrentVersion(ctx, sdkclient.WorkerDeploymentSetCurrentVersionOptions{
-				BuildID:                 buildID,
-				ConflictToken:           descResp.ConflictToken,
-				IgnoreMissingTaskQueues: true,
-			}); err != nil {
-				return fmt.Errorf("revert to v1.0: %w", err)
-			}
-			return fmt.Errorf("reverted to v1.0, retrying")
-		}
-		if _, err := deploymentHandle.SetRampingVersion(ctx, sdkclient.WorkerDeploymentSetRampingVersionOptions{
-			BuildID:       buildIDv2,
-			Percentage:    50,
-			ConflictToken: descResp.ConflictToken,
-			Identity:      "test",
-		}); err != nil {
-			return err
-		}
-		return nil
-	})
+	setRampingVersion(t, ctx, ts, workerDeploymentName, buildIDv2, 50)
 	t.Logf("Set v2.0 (buildID=%s) as ramping version at 50%%", buildIDv2)
 
 	// Verify the TWD has our finalizer

--- a/internal/tests/internal/deletion_integration_test.go
+++ b/internal/tests/internal/deletion_integration_test.go
@@ -1,0 +1,314 @@
+package internal
+
+// Tests that deleting a TemporalWorkerDeployment CRD correctly cleans up
+// Temporal server-side versioning data and handles edge cases like the
+// TemporalConnection being deleted simultaneously by Helm.
+//
+// Covered:
+//   - TWD deletion sets current version to unversioned on Temporal server
+//   - TWD deletion removes finalizer from TemporalConnection when no other TWDs reference it
+//   - TWD is fully deleted from K8s after cleanup (finalizer removed)
+//   - TWD deletion with TemporalConnection deleted simultaneously (Helm race condition) still succeeds
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	temporaliov1alpha1 "github.com/temporalio/temporal-worker-controller/api/v1alpha1"
+	"github.com/temporalio/temporal-worker-controller/internal/k8s"
+	"github.com/temporalio/temporal-worker-controller/internal/testhelpers"
+	"go.temporal.io/api/serviceerror"
+	sdkclient "go.temporal.io/sdk/client"
+	"go.temporal.io/server/temporaltest"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+const deletionFinalizerName = "temporal.io/delete-protection"
+
+func runDeletionTests(
+	t *testing.T,
+	k8sClient client.Client,
+	mgr manager.Manager,
+	ts *temporaltest.TestServer,
+	testNamespace string,
+) {
+	t.Run("deletion-sets-current-to-unversioned", func(t *testing.T) {
+		testDeletionSetsCurrentToUnversioned(t, k8sClient, mgr, ts, testNamespace)
+	})
+
+	t.Run("deletion-removes-connection-finalizer", func(t *testing.T) {
+		testDeletionRemovesConnectionFinalizer(t, k8sClient, mgr, ts, testNamespace)
+	})
+}
+
+// testDeletionSetsCurrentToUnversioned verifies the core fix: when a TWD is deleted,
+// the controller sets the current version to unversioned so tasks route to unversioned workers,
+// and the TWD is fully deleted from K8s.
+func testDeletionSetsCurrentToUnversioned(
+	t *testing.T,
+	k8sClient client.Client,
+	mgr manager.Manager,
+	ts *temporaltest.TestServer,
+	namespace string,
+) {
+	ctx := context.Background()
+	testName := "del-cleanup"
+
+	// Build a TWD using the standard builder pattern
+	tc := testhelpers.NewTestCase().
+		WithInput(
+			testhelpers.NewTemporalWorkerDeploymentBuilder().
+				WithAllAtOnceStrategy().
+				WithTargetTemplate("v1.0"),
+		).
+		WithExpectedStatus(
+			testhelpers.NewStatusBuilder().
+				WithTargetVersion("v1.0", temporaliov1alpha1.VersionStatusCurrent, -1, true, false).
+				WithCurrentVersion("v1.0", true, false),
+		).
+		BuildWithValues(testName, namespace, ts.GetDefaultNamespace())
+
+	twd := tc.GetTWD()
+
+	// Create a TemporalConnection
+	temporalConnection := &temporaliov1alpha1.TemporalConnection{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      twd.Spec.WorkerOptions.TemporalConnectionRef.Name,
+			Namespace: namespace,
+		},
+		Spec: temporaliov1alpha1.TemporalConnectionSpec{
+			HostPort: ts.GetFrontendHostPort(),
+		},
+	}
+	if err := k8sClient.Create(ctx, temporalConnection); err != nil {
+		t.Fatalf("failed to create TemporalConnection: %v", err)
+	}
+
+	// Create the TWD
+	if err := k8sClient.Create(ctx, twd); err != nil {
+		t.Fatalf("failed to create TWD: %v", err)
+	}
+
+	// Wait for the child deployment to be created by the controller
+	workerDeploymentName := k8s.ComputeWorkerDeploymentName(twd)
+	buildID := k8s.ComputeBuildID(twd)
+	expectedDeploymentName := k8s.ComputeVersionedDeploymentName(twd.Name, buildID)
+
+	eventually(t, 30*time.Second, time.Second, func() error {
+		var dep appsv1.Deployment
+		return k8sClient.Get(ctx, types.NamespacedName{
+			Name: expectedDeploymentName, Namespace: namespace,
+		}, &dep)
+	})
+
+	// Start workers so the version registers on the Temporal server
+	env := testhelpers.TestEnv{
+		K8sClient:  k8sClient,
+		Mgr:        mgr,
+		Ts:         ts,
+		Connection: temporalConnection,
+	}
+	workerStopFuncs := applyDeployment(t, ctx, k8sClient, expectedDeploymentName, namespace)
+	defer handleStopFuncs(workerStopFuncs)
+
+	// Wait until the version becomes current on the Temporal server
+	deploymentHandle := ts.GetDefaultClient().WorkerDeploymentClient().GetHandle(workerDeploymentName)
+	eventually(t, 60*time.Second, 2*time.Second, func() error {
+		resp, err := deploymentHandle.Describe(ctx, sdkclient.WorkerDeploymentDescribeOptions{})
+		if err != nil {
+			return err
+		}
+		if resp.Info.RoutingConfig.CurrentVersion == nil {
+			return errors.New("current version not set yet")
+		}
+		return nil
+	})
+	t.Log("TWD is reconciled with a current version set")
+
+	// Verify the TWD has our finalizer
+	var twdBeforeDelete temporaliov1alpha1.TemporalWorkerDeployment
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: twd.Name, Namespace: namespace}, &twdBeforeDelete); err != nil {
+		t.Fatalf("failed to get TWD: %v", err)
+	}
+	hasFinalizer := false
+	for _, f := range twdBeforeDelete.Finalizers {
+		if f == deletionFinalizerName {
+			hasFinalizer = true
+			break
+		}
+	}
+	if !hasFinalizer {
+		t.Fatalf("TWD does not have expected finalizer %q", deletionFinalizerName)
+	}
+
+	// Delete the TWD
+	t.Log("Deleting the TemporalWorkerDeployment")
+	if err := k8sClient.Delete(ctx, &twdBeforeDelete); err != nil {
+		t.Fatalf("failed to delete TWD: %v", err)
+	}
+
+	// Verify the TWD is eventually deleted (finalizer ran and was removed)
+	eventually(t, 60*time.Second, 2*time.Second, func() error {
+		var check temporaliov1alpha1.TemporalWorkerDeployment
+		err := k8sClient.Get(ctx, types.NamespacedName{Name: twd.Name, Namespace: namespace}, &check)
+		if err != nil {
+			return nil // not found = deleted
+		}
+		return errors.New("TWD still exists, finalizer may not have completed")
+	})
+	t.Log("TWD deleted successfully (finalizer completed)")
+
+	// Verify Temporal server-side state: current version should be unversioned
+	resp, err := deploymentHandle.Describe(ctx, sdkclient.WorkerDeploymentDescribeOptions{})
+	if err != nil {
+		var notFound *serviceerror.NotFound
+		if errors.As(err, &notFound) {
+			t.Log("Worker Deployment was fully deleted from Temporal server")
+			return
+		}
+		t.Fatalf("failed to describe worker deployment after deletion: %v", err)
+	}
+
+	if resp.Info.RoutingConfig.CurrentVersion != nil {
+		t.Errorf("expected current version to be nil (unversioned) after TWD deletion, got buildID=%q",
+			resp.Info.RoutingConfig.CurrentVersion.BuildID)
+	} else {
+		t.Log("Verified: current version is unversioned after TWD deletion")
+	}
+
+	// Suppress unused variable warning for env
+	_ = env
+}
+
+// testDeletionRemovesConnectionFinalizer verifies that when a TWD is deleted,
+// the controller removes its finalizer from the TemporalConnection, allowing
+// the connection to be deleted by K8s. This tests the Helm race condition fix.
+func testDeletionRemovesConnectionFinalizer(
+	t *testing.T,
+	k8sClient client.Client,
+	mgr manager.Manager,
+	ts *temporaltest.TestServer,
+	namespace string,
+) {
+	ctx := context.Background()
+	testName := "del-conn-finalizer"
+
+	// Build a TWD with manual strategy (simpler, no need to reach current version)
+	tc := testhelpers.NewTestCase().
+		WithInput(
+			testhelpers.NewTemporalWorkerDeploymentBuilder().
+				WithManualStrategy().
+				WithTargetTemplate("v1.0"),
+		).
+		WithExpectedStatus(
+			testhelpers.NewStatusBuilder().
+				WithTargetVersion("v1.0", temporaliov1alpha1.VersionStatusInactive, -1, true, false),
+		).
+		BuildWithValues(testName, namespace, ts.GetDefaultNamespace())
+
+	twd := tc.GetTWD()
+
+	// Create a TemporalConnection
+	temporalConnection := &temporaliov1alpha1.TemporalConnection{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      twd.Spec.WorkerOptions.TemporalConnectionRef.Name,
+			Namespace: namespace,
+		},
+		Spec: temporaliov1alpha1.TemporalConnectionSpec{
+			HostPort: ts.GetFrontendHostPort(),
+		},
+	}
+	if err := k8sClient.Create(ctx, temporalConnection); err != nil {
+		t.Fatalf("failed to create TemporalConnection: %v", err)
+	}
+
+	// Create the TWD
+	if err := k8sClient.Create(ctx, twd); err != nil {
+		t.Fatalf("failed to create TWD: %v", err)
+	}
+
+	// Wait for the finalizer to be added to both TWD and TemporalConnection
+	eventually(t, 30*time.Second, time.Second, func() error {
+		var check temporaliov1alpha1.TemporalWorkerDeployment
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: twd.Name, Namespace: namespace}, &check); err != nil {
+			return err
+		}
+		for _, f := range check.Finalizers {
+			if f == deletionFinalizerName {
+				return nil
+			}
+		}
+		return fmt.Errorf("TWD finalizer %q not yet added", deletionFinalizerName)
+	})
+
+	eventually(t, 30*time.Second, time.Second, func() error {
+		var check temporaliov1alpha1.TemporalConnection
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: temporalConnection.Name, Namespace: namespace}, &check); err != nil {
+			return err
+		}
+		for _, f := range check.Finalizers {
+			if f == deletionFinalizerName {
+				return nil
+			}
+		}
+		return fmt.Errorf("TemporalConnection finalizer %q not yet added", deletionFinalizerName)
+	})
+	t.Log("Both finalizers are in place")
+
+	// Simulate Helm deleting both resources simultaneously by deleting the
+	// TemporalConnection first, then the TWD. The connection should be blocked
+	// by the finalizer until the TWD cleanup removes it.
+	if err := k8sClient.Delete(ctx, temporalConnection); err != nil {
+		t.Fatalf("failed to delete TemporalConnection: %v", err)
+	}
+	t.Log("TemporalConnection deletion requested (blocked by finalizer)")
+
+	// Verify the connection is NOT yet deleted (finalizer holds it)
+	var connCheck temporaliov1alpha1.TemporalConnection
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: temporalConnection.Name, Namespace: namespace}, &connCheck); err != nil {
+		t.Fatalf("TemporalConnection should still exist (held by finalizer), but got: %v", err)
+	}
+	if connCheck.DeletionTimestamp.IsZero() {
+		t.Fatal("TemporalConnection should have DeletionTimestamp set")
+	}
+	t.Log("Verified: TemporalConnection is in Terminating state (held by finalizer)")
+
+	// Now delete the TWD
+	var latestTwd temporaliov1alpha1.TemporalWorkerDeployment
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: twd.Name, Namespace: namespace}, &latestTwd); err != nil {
+		t.Fatalf("failed to get TWD: %v", err)
+	}
+	if err := k8sClient.Delete(ctx, &latestTwd); err != nil {
+		t.Fatalf("failed to delete TWD: %v", err)
+	}
+
+	// Verify the TWD is eventually deleted
+	eventually(t, 60*time.Second, 2*time.Second, func() error {
+		var check temporaliov1alpha1.TemporalWorkerDeployment
+		err := k8sClient.Get(ctx, types.NamespacedName{Name: twd.Name, Namespace: namespace}, &check)
+		if err != nil {
+			return nil // deleted
+		}
+		return errors.New("TWD still exists")
+	})
+	t.Log("TWD deleted successfully")
+
+	// Verify the TemporalConnection is also eventually deleted
+	// (controller removed the finalizer during TWD cleanup, K8s can now delete it)
+	eventually(t, 60*time.Second, 2*time.Second, func() error {
+		var check temporaliov1alpha1.TemporalConnection
+		err := k8sClient.Get(ctx, types.NamespacedName{Name: temporalConnection.Name, Namespace: namespace}, &check)
+		if err != nil {
+			return nil // deleted
+		}
+		return errors.New("TemporalConnection still exists after TWD cleanup")
+	})
+	t.Log("TemporalConnection deleted successfully (finalizer was removed by TWD cleanup)")
+}

--- a/internal/tests/internal/deletion_integration_test.go
+++ b/internal/tests/internal/deletion_integration_test.go
@@ -160,37 +160,48 @@ func testDeletionSetsCurrentToUnversioned(
 		return fmt.Errorf("v2.0 (buildID=%s) not yet visible in Temporal deployment", buildIDv2)
 	})
 
-	// Set v2.0 as the ramping version to exercise the clear-ramping path on deletion.
-	// The AllAtOnce controller may have already promoted v2.0 to current by the time we get
-	// here, so we first revert to v1.0 as current (pushing v2.0 back to inactive) then set
-	// v2.0 as ramping.
-	descResp, err := deploymentHandle.Describe(ctx, sdkclient.WorkerDeploymentDescribeOptions{})
+	// Create a client matching the controller's ManagerIdentity so we can revert the
+	// current version when the AllAtOnce controller has already promoted v2.0.
+	controllerClient, err := sdkclient.Dial(sdkclient.Options{
+		HostPort:  ts.GetFrontendHostPort(),
+		Namespace: ts.GetDefaultNamespace(),
+		Identity:  "temporal-worker-controller",
+	})
 	if err != nil {
-		t.Fatalf("failed to describe deployment before setting ramping version: %v", err)
+		t.Fatalf("failed to create controller-identity client: %v", err)
 	}
-	if descResp.Info.RoutingConfig.CurrentVersion != nil && descResp.Info.RoutingConfig.CurrentVersion.BuildID == buildIDv2 {
-		// v2.0 is already current; revert to v1.0 so we can set v2.0 as ramping.
-		t.Logf("v2.0 is already current; reverting to v1.0 as current before setting v2.0 as ramping")
-		if _, err := deploymentHandle.SetCurrentVersion(ctx, sdkclient.WorkerDeploymentSetCurrentVersionOptions{
-			BuildID:                 buildID,
-			ConflictToken:           descResp.ConflictToken,
-			IgnoreMissingTaskQueues: true,
-		}); err != nil {
-			t.Fatalf("failed to revert current version to v1.0: %v", err)
-		}
-		descResp, err = deploymentHandle.Describe(ctx, sdkclient.WorkerDeploymentDescribeOptions{})
+	defer controllerClient.Close()
+	controllerHandle := controllerClient.WorkerDeploymentClient().GetHandle(workerDeploymentName)
+
+	// Set v2.0 as the ramping version to exercise the clear-ramping path on deletion.
+	// The AllAtOnce controller races to promote v2.0 to current; retry until we win:
+	// if v2.0 is already current, revert to v1.0 using the controller identity, then retry.
+	eventually(t, 30*time.Second, time.Second, func() error {
+		descResp, err := deploymentHandle.Describe(ctx, sdkclient.WorkerDeploymentDescribeOptions{})
 		if err != nil {
-			t.Fatalf("failed to re-describe deployment after reverting current version: %v", err)
+			return err
 		}
-	}
-	if _, err := deploymentHandle.SetRampingVersion(ctx, sdkclient.WorkerDeploymentSetRampingVersionOptions{
-		BuildID:       buildIDv2,
-		Percentage:    50,
-		ConflictToken: descResp.ConflictToken,
-		Identity:      "test",
-	}); err != nil {
-		t.Fatalf("failed to set v2.0 as ramping version: %v", err)
-	}
+		if descResp.Info.RoutingConfig.CurrentVersion != nil && descResp.Info.RoutingConfig.CurrentVersion.BuildID == buildIDv2 {
+			t.Logf("v2.0 is already current; reverting to v1.0 before setting v2.0 as ramping")
+			if _, err := controllerHandle.SetCurrentVersion(ctx, sdkclient.WorkerDeploymentSetCurrentVersionOptions{
+				BuildID:                 buildID,
+				ConflictToken:           descResp.ConflictToken,
+				IgnoreMissingTaskQueues: true,
+			}); err != nil {
+				return fmt.Errorf("revert to v1.0: %w", err)
+			}
+			return fmt.Errorf("reverted to v1.0, retrying")
+		}
+		if _, err := deploymentHandle.SetRampingVersion(ctx, sdkclient.WorkerDeploymentSetRampingVersionOptions{
+			BuildID:       buildIDv2,
+			Percentage:    50,
+			ConflictToken: descResp.ConflictToken,
+			Identity:      "test",
+		}); err != nil {
+			return err
+		}
+		return nil
+	})
 	t.Logf("Set v2.0 (buildID=%s) as ramping version at 50%%", buildIDv2)
 
 	// Verify the TWD has our finalizer

--- a/internal/tests/internal/deletion_integration_test.go
+++ b/internal/tests/internal/deletion_integration_test.go
@@ -160,10 +160,28 @@ func testDeletionSetsCurrentToUnversioned(
 		return fmt.Errorf("v2.0 (buildID=%s) not yet visible in Temporal deployment", buildIDv2)
 	})
 
-	// Set v2.0 as the ramping version so we exercise the clear-ramping path on deletion
+	// Set v2.0 as the ramping version to exercise the clear-ramping path on deletion.
+	// The AllAtOnce controller may have already promoted v2.0 to current by the time we get
+	// here, so we first revert to v1.0 as current (pushing v2.0 back to inactive) then set
+	// v2.0 as ramping.
 	descResp, err := deploymentHandle.Describe(ctx, sdkclient.WorkerDeploymentDescribeOptions{})
 	if err != nil {
 		t.Fatalf("failed to describe deployment before setting ramping version: %v", err)
+	}
+	if descResp.Info.RoutingConfig.CurrentVersion != nil && descResp.Info.RoutingConfig.CurrentVersion.BuildID == buildIDv2 {
+		// v2.0 is already current; revert to v1.0 so we can set v2.0 as ramping.
+		t.Logf("v2.0 is already current; reverting to v1.0 as current before setting v2.0 as ramping")
+		if _, err := deploymentHandle.SetCurrentVersion(ctx, sdkclient.WorkerDeploymentSetCurrentVersionOptions{
+			BuildID:                buildID,
+			ConflictToken:          descResp.ConflictToken,
+			IgnoreMissingTaskQueues: true,
+		}); err != nil {
+			t.Fatalf("failed to revert current version to v1.0: %v", err)
+		}
+		descResp, err = deploymentHandle.Describe(ctx, sdkclient.WorkerDeploymentDescribeOptions{})
+		if err != nil {
+			t.Fatalf("failed to re-describe deployment after reverting current version: %v", err)
+		}
 	}
 	if _, err := deploymentHandle.SetRampingVersion(ctx, sdkclient.WorkerDeploymentSetRampingVersionOptions{
 		BuildID:       buildIDv2,

--- a/internal/tests/internal/deletion_integration_test.go
+++ b/internal/tests/internal/deletion_integration_test.go
@@ -27,7 +27,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 const deletionFinalizerName = "temporal.io/delete-protection"
@@ -35,16 +34,15 @@ const deletionFinalizerName = "temporal.io/delete-protection"
 func runDeletionTests(
 	t *testing.T,
 	k8sClient client.Client,
-	mgr manager.Manager,
 	ts *temporaltest.TestServer,
 	testNamespace string,
 ) {
 	t.Run("deletion-sets-current-to-unversioned", func(t *testing.T) {
-		testDeletionSetsCurrentToUnversioned(t, k8sClient, mgr, ts, testNamespace)
+		testDeletionSetsCurrentToUnversioned(t, k8sClient, ts, testNamespace)
 	})
 
 	t.Run("deletion-removes-connection-finalizer", func(t *testing.T) {
-		testDeletionRemovesConnectionFinalizer(t, k8sClient, mgr, ts, testNamespace)
+		testDeletionRemovesConnectionFinalizer(t, k8sClient, ts, testNamespace)
 	})
 }
 
@@ -54,7 +52,6 @@ func runDeletionTests(
 func testDeletionSetsCurrentToUnversioned(
 	t *testing.T,
 	k8sClient client.Client,
-	mgr manager.Manager,
 	ts *temporaltest.TestServer,
 	namespace string,
 ) {
@@ -109,12 +106,6 @@ func testDeletionSetsCurrentToUnversioned(
 	})
 
 	// Start workers so the version registers on the Temporal server
-	env := testhelpers.TestEnv{
-		K8sClient:  k8sClient,
-		Mgr:        mgr,
-		Ts:         ts,
-		Connection: temporalConnection,
-	}
 	workerStopFuncs := applyDeployment(t, ctx, k8sClient, expectedDeploymentName, namespace)
 	defer handleStopFuncs(workerStopFuncs)
 
@@ -182,9 +173,6 @@ func testDeletionSetsCurrentToUnversioned(
 	} else {
 		t.Log("Verified: current version is unversioned after TWD deletion")
 	}
-
-	// Suppress unused variable warning for env
-	_ = env
 }
 
 // testDeletionRemovesConnectionFinalizer verifies that when a TWD is deleted,
@@ -193,7 +181,6 @@ func testDeletionSetsCurrentToUnversioned(
 func testDeletionRemovesConnectionFinalizer(
 	t *testing.T,
 	k8sClient client.Client,
-	mgr manager.Manager,
 	ts *temporaltest.TestServer,
 	namespace string,
 ) {

--- a/internal/tests/internal/integration_test.go
+++ b/internal/tests/internal/integration_test.go
@@ -964,7 +964,7 @@ func TestIntegration(t *testing.T) {
 
 	// Deletion cleanup tests — use short poller TTL server so active pollers expire
 	// in 1s rather than the default 5 minutes, keeping test runtime reasonable.
-	runDeletionTests(t, k8sClient, mgr, tsShortTTL, testNamespace.Name)
+	runDeletionTests(t, k8sClient, tsShortTTL, testNamespace.Name)
 }
 
 // testTemporalWorkerDeploymentCreation tests the creation of a TemporalWorkerDeployment and waits for the expected status

--- a/internal/tests/internal/integration_test.go
+++ b/internal/tests/internal/integration_test.go
@@ -961,6 +961,10 @@ func TestIntegration(t *testing.T) {
 		temporaltest.WithBaseServerOptions(temporal.WithDynamicConfigClient(dcRateLimit)),
 	)
 	runRateLimitTest(t, k8sClient, tsRateLimit, testNamespace.Name)
+
+	// Deletion cleanup tests — use short poller TTL server so active pollers expire
+	// in 1s rather than the default 5 minutes, keeping test runtime reasonable.
+	runDeletionTests(t, k8sClient, mgr, tsShortTTL, testNamespace.Name)
 }
 
 // testTemporalWorkerDeploymentCreation tests the creation of a TemporalWorkerDeployment and waits for the expected status


### PR DESCRIPTION

- Add a finalizer to `TemporalWorkerDeployment` to run Temporal server-side cleanup before K8s deletion
- Add a finalizer to `TemporalConnection` to prevent it from being deleted while any TWD still references it
- On TWD deletion, set current version to unversioned, clear ramping version, and delete registered versions

## Problem

When a `TemporalWorkerDeployment` CRD is deleted (e.g., switching back to plain Deployments), the Temporal server retains the build ID routing configuration. The matching service continues routing new tasks to the deleted build ID's physical queue, while unversioned workers poll a different physical queue. Tasks sit in `Scheduled` state indefinitely with no errors.

A secondary race condition exists: Helm deletes both the `TemporalConnection` and `TWD` in the same upgrade. Without the connection, the controller cannot talk to Temporal to clean up. This is solved by adding a finalizer to the `TemporalConnection` that blocks its deletion until all referencing TWDs are gone.

## Changes

**`internal/controller/worker_controller.go`:**

**TWD finalizer (`temporal.io/worker-deployment-cleanup`):**
- Added to all TWD resources during normal reconciliation
- On deletion, triggers `handleDeletion()` which:
  1. Sets the current version to unversioned (`BuildID: ""`) -- the critical step that unblocks task dispatch
  2. Clears any ramping version
  3. Deletes all registered versions with `SkipDrainage: true`
  4. Attempts to delete the deployment record itself
  5. Removes the connection finalizer if no other TWDs reference it
  6. Removes its own finalizer, allowing K8s to complete deletion

**TemporalConnection finalizer (`temporal.io/connection-in-use`):**
- Added to the `TemporalConnection` during normal TWD reconciliation via `ensureConnectionFinalizer()`
- Prevents the connection from being deleted while any TWD still references it
- Removed by `removeConnectionFinalizerIfUnused()` during TWD deletion, after checking no other TWDs in the same namespace reference the connection
- Guarantees the connection is always available during TWD cleanup -- no race condition with Helm deleting both resources simultaneously

**RBAC updates:**
- Added `update;patch` verbs for `temporalconnections` (was `get;list;watch`)
- Added `update` verb for `temporalconnections/finalizers`

## Deletion flow

```
Helm upgrade (TWD disabled)
  |
  v
Helm deletes TWD CRD + TemporalConnection CRD simultaneously
  |
  +--> TemporalConnection: has finalizer, K8s sets DeletionTimestamp but blocks deletion
  |
  +--> TWD: has finalizer, K8s sets DeletionTimestamp, triggers Reconcile
         |
         v
       handleDeletion() runs:
         1. Fetches TemporalConnection (guaranteed to exist via finalizer)
         2. Connects to Temporal server
         3. Sets current version to unversioned
         4. Deletes versions
         5. Removes connection finalizer (no other TWDs reference it)
         6. Removes TWD finalizer
         |
         v
       TWD deleted by K8s
         |
         v
       TemporalConnection: no more finalizers, deleted by K8s
```

Issue #55 
Closes #166
