### PR TITLE
docs: add Helm ownership labeling step to CRD migration guide

### DIFF
--- a/docs/crd-management.md
+++ b/docs/crd-management.md
@@ -125,8 +125,23 @@ helm upgrade temporal-worker-controller \
   --version <new-version> \
   --namespace temporal-system
 
-# Step 2: Install the CRDs chart to take Helm ownership of the existing CRDs
-# kubectl apply reconciles any changes; same-version CRDs are a no-op on the cluster
+# Step 2: Stamp Helm ownership labels/annotations onto the existing CRDs.
+# CRDs installed via the old `crds/` directory have no Helm tracking metadata.
+# Without this step, `helm install` in step 3 fails with "cannot be imported into
+# the current release: invalid ownership metadata".
+kubectl label crd \
+  temporalconnections.temporal.io \
+  temporalworkerdeployments.temporal.io \
+  app.kubernetes.io/managed-by=Helm --overwrite
+
+kubectl annotate crd \
+  temporalconnections.temporal.io \
+  temporalworkerdeployments.temporal.io \
+  meta.helm.sh/release-name=temporal-worker-controller-crds \
+  meta.helm.sh/release-namespace=temporal-system --overwrite
+
+# Step 3: Install the CRDs chart to take Helm ownership of the existing CRDs.
+# Same-version CRDs are a no-op on the cluster.
 helm install temporal-worker-controller-crds \
   oci://docker.io/temporalio/temporal-worker-controller-crds \
   --version <new-version> \


### PR DESCRIPTION
## Summary
- Adds a required `kubectl label` + `kubectl annotate` step to the CRD migration instructions
- Without this, `helm install` of the new CRDs chart fails with "cannot be imported into the current release: invalid ownership metadata"
- Discovered during demo setup when migrating from previously-installed CRDs to the new charts format

Extracted from #217 per [this comment](https://github.com/temporalio/temporal-worker-controller/pull/217/changes/BASE..d6d8f7ce7f5651529c7cdf216fe1a8b4fbecbe1a#r2986526435) — this needs to land independently in the chart version where CRDs are first split out.

## Test plan
- [ ] Verify the migration steps work on a cluster with pre-existing CRDs installed via the old `crds/` directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)