### PR TITLE
bump helm chart version to 0.20.0

### DIFF
--- a/helm/temporal-worker-controller/Chart.yaml
+++ b/helm/temporal-worker-controller/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: temporal-worker-controller
 description: A Helm chart for the Temporal Worker Controller
 type: application
-version: 0.19.0
+version: 0.20.0
 appVersion: 1.3.1


### PR DESCRIPTION
## Summary
- Bumps the `temporal-worker-controller` Helm chart version from `0.19.0` to `0.20.0` to reflect the latest helm chart version which was released.

## Test plan
- [ ] Verify the Helm chart publishes correctly with version `0.20.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)