### PR TITLE
Bump chart version to 0.21.0 with appVersion 1.4.0

### DIFF
--- a/helm/temporal-worker-controller-crds/Chart.yaml
+++ b/helm/temporal-worker-controller-crds/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: temporal-worker-controller-crds
 description: CRDs for the Temporal Worker Controller. Install this chart before the temporal-worker-controller chart.
 type: application
-version: 0.12.0
+version: 0.13.0

--- a/helm/temporal-worker-controller/Chart.yaml
+++ b/helm/temporal-worker-controller/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: temporal-worker-controller
 description: A Helm chart for the Temporal Worker Controller
 type: application
-version: 0.20.0
-appVersion: 1.3.1
+version: 0.21.0
+appVersion: 1.4.0


### PR DESCRIPTION
## Summary
- Controller chart: `0.20.0` → `0.21.0`, appVersion `1.3.1` → `1.4.0`
- CRDs chart: `0.12.0` → `0.13.0` (adds `managerIdentity` field to TWD CRD)

## Why
Preparing for v1.4.0 release. These version bumps need to land on main before creating the `release/v1.4.0` branch.

## Test plan
- [ ] Merge to main
- [ ] Create `release/v1.4.0` branch from main
- [ ] Run upgrade/downgrade pipeline: v1.3.1 ↔ v1.4.0
- [ ] Deploy to dogfooding environments (test + prod)
- [ ] Cut release tomorrow morning

🤖 Generated with [Claude Code](https://claude.com/claude-code)