### PR TITLE
Revert cert-manager version constraint to ">=v1.0.0" from 0.23.0 wrongly added by CI

### DIFF
--- a/helm/temporal-worker-controller/Chart.yaml
+++ b/helm/temporal-worker-controller/Chart.yaml
@@ -6,6 +6,6 @@ version: 0.23.0
 appVersion: 1.5.0
 dependencies:
   - name: cert-manager
-    version: ">=1.0.0"
+    version: ">=v1.0.0"
     repository: "https://charts.jetstack.io"
     condition: certmanager.install


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed and why
The CI job that bumps the versions in main also wrongly bumped the cert-manager dependency constraint here: https://github.com/temporalio/temporal-worker-controller/commit/1805045fe4890e199ee3b2960533ac19a24f8232 causing build and release error

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
