### PR TITLE
Skip automatic helm chart bump for patch releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,6 @@ jobs:
 
   helm:
     needs: release
-    if: endsWith(github.ref_name, '.0')
     runs-on: ubuntu-latest
     steps:
 
@@ -100,14 +99,24 @@ jobs:
           CURRENT_VERSION=$(grep 'version:' helm/temporal-worker-controller/Chart.yaml | awk '{print $2}')
           echo "Current version: $CURRENT_VERSION"
 
-          # Split version into parts
+          # Determine if this is a patch release based on the git tag
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          TAG_PATCH=$(echo "$TAG_VERSION" | awk -F. '{print $3}')
+
+          # Split chart version into parts
           IFS='.' read -r -a VERSION_PARTS <<< "$CURRENT_VERSION"
           MAJOR=${VERSION_PARTS[0]}
           MINOR=${VERSION_PARTS[1]}
           PATCH=${VERSION_PARTS[2]}
 
-          MINOR=$((MINOR + 1))
-          PATCH=0
+          if [[ "$TAG_PATCH" == "0" ]]; then
+            # Non-patch release: bump chart minor version
+            MINOR=$((MINOR + 1))
+            PATCH=0
+          else
+            # Patch release: bump chart patch version
+            PATCH=$((PATCH + 1))
+          fi
 
           NEW_VERSION="$MAJOR.$MINOR.$PATCH"
           echo "New version: $NEW_VERSION"


### PR DESCRIPTION
## Summary
- Updates the `helm` job in `release.yml` to detect patch vs non-patch releases from the git tag
- Non-patch releases (e.g. `v1.5.0`) → bump chart **minor** version (e.g. `0.23.0` → `0.24.0`)
- Patch releases (e.g. `v1.5.1`) → bump chart **patch** version (e.g. `0.23.0` → `0.23.1`)
- `appVersion` is always set from the git tag in both cases

## Test plan
- [ ] Tag a `.0` release → helm job bumps chart minor version
- [ ] Tag a patch release (e.g. `.1`) → helm job bumps chart patch version

🤖 Generated with [Claude Code](https://claude.com/claude-code)