### PR TITLE
Fix greedy sed in release.yml and restore cert-manager constraint

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,7 @@ jobs:
         id: bump_version
         run: |
           # Get current version from Chart.yaml
-          CURRENT_VERSION=$(grep 'version:' helm/temporal-worker-controller/Chart.yaml | awk '{print $2}')
+          CURRENT_VERSION=$(grep '^version:' helm/temporal-worker-controller/Chart.yaml | awk '{print $2}')
           echo "Current version: $CURRENT_VERSION"
 
           # Determine if this is a patch release based on the git tag
@@ -121,12 +121,14 @@ jobs:
           NEW_VERSION="$MAJOR.$MINOR.$PATCH"
           echo "New version: $NEW_VERSION"
 
-          # Update Chart.yaml with new version and appVersion
-          sed -i "s/version: .*/version: $NEW_VERSION/" helm/temporal-worker-controller/Chart.yaml
+          # Update Chart.yaml with new version and appVersion.
+          # Use ^version: to only match the top-level chart version, not indented
+          # dependency versions (e.g. cert-manager) which would otherwise be overwritten.
+          sed -i "s/^version: .*/version: $NEW_VERSION/" helm/temporal-worker-controller/Chart.yaml
           sed -i "s/appVersion: .*/appVersion: ${GITHUB_REF_NAME#v}/" helm/temporal-worker-controller/Chart.yaml
 
           # Also bump CRDs chart version
-          sed -i "s/version: .*/version: $NEW_VERSION/" helm/temporal-worker-controller-crds/Chart.yaml
+          sed -i "s/^version: .*/version: $NEW_VERSION/" helm/temporal-worker-controller-crds/Chart.yaml
 
           # Set output variable for use in later steps
           echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"

--- a/helm/temporal-worker-controller/Chart.lock
+++ b/helm/temporal-worker-controller/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: cert-manager
   repository: https://charts.jetstack.io
-  version: v1.20.0
-digest: sha256:2e79d5fcaa7105af9b35257a74b2ae955a6d73cd0cfa33b8c132e210673eb14a
-generated: "2026-03-19T19:11:27.515922-07:00"
+  version: v1.20.1
+digest: sha256:34ef5f9babc7487216ac192df771477dce47e7acc6480177473bbdc4fc61e381
+generated: "2026-04-01T12:22:50.99819-04:00"

--- a/helm/temporal-worker-controller/Chart.yaml
+++ b/helm/temporal-worker-controller/Chart.yaml
@@ -6,6 +6,6 @@ version: 0.24.0
 appVersion: 1.5.1
 dependencies:
   - name: cert-manager
-    version: 0.24.0
+    version: ">=v1.0.0"
     repository: "https://charts.jetstack.io"
     condition: certmanager.install


### PR DESCRIPTION
## Summary
- Restores cert-manager dependency version constraint to `">=v1.0.0"` (was overwritten to `0.24.0` by the `v1.5.1` release pipeline)
- Fixes the root cause: `sed` commands in `release.yml` used `s/version: .*/...` which matched **all** `version:` lines, including indented dependency versions. Now anchored with `^` to only match the top-level chart version
- Updates `Chart.lock` to be in sync with the restored `Chart.yaml`

## Context
When the `v1.5.1` release was published, `release.yml`'s helm job:
1. Overwrote the cert-manager constraint from `">=v1.0.0"` to `0.24.0` (same bug as #252)
2. `helm package` then failed because cert-manager `0.24.0` doesn't exist in the jetstack repo
3. The controller chart `0.24.0` was **never published**, but the CRDs chart `0.24.0` was

## After merge
Trigger `helm.yml` manually with `version_bump: none`, `ref: main` to publish the controller chart `0.24.0` with `appVersion: 1.5.1`.

## Test plan
- [ ] CI passes
- [ ] After merge, trigger `helm.yml` with `version_bump: none`, `ref: main`
- [ ] Verify controller chart `0.24.0` is published to Docker Hub

🤖 Generated with [Claude Code](https://claude.com/claude-code)