### PR TITLE
Add extra field when doing SubjectAccessReview

### DIFF
--- a/api/v1alpha1/workerresourcetemplate_webhook.go
+++ b/api/v1alpha1/workerresourcetemplate_webhook.go
@@ -470,7 +470,11 @@ func (v *WorkerResourceTemplateValidator) validateWithAPI(ctx context.Context, w
 			Spec: authorizationv1.SubjectAccessReviewSpec{
 				User:   req.UserInfo.Username,
 				Groups: req.UserInfo.Groups,
-				Extra:  convertUserInfoExtra(req.UserInfo.Extra),
+				// Some authentication plugins like GKE's IAM plugin rely on certain fields being
+				// present in the UserInfo.Extra field, so here we make sure to copy any extra
+				// field values from the authentication request into the extra field of the
+				// authorization review.
+				Extra: convertUserInfoExtra(req.UserInfo.Extra),
 				ResourceAttributes: &authorizationv1.ResourceAttributes{
 					Namespace: wrt.Namespace,
 					Verb:      verb,

--- a/api/v1alpha1/workerresourcetemplate_webhook.go
+++ b/api/v1alpha1/workerresourcetemplate_webhook.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 
+	authenticationv1 "k8s.io/api/authentication/v1"
 	authorizationv1 "k8s.io/api/authorization/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -390,6 +391,19 @@ func isEmptyMap(v interface{}) bool {
 	return ok && len(m) == 0
 }
 
+// convertUserInfoExtra converts an authentication ExtraValue map to an authorization ExtraValue map.
+// Both types are []string under the hood; the conversion preserves all values exactly.
+func convertUserInfoExtra(extra map[string]authenticationv1.ExtraValue) map[string]authorizationv1.ExtraValue {
+	if len(extra) == 0 {
+		return nil
+	}
+	out := make(map[string]authorizationv1.ExtraValue, len(extra))
+	for k, v := range extra {
+		out[k] = authorizationv1.ExtraValue(v)
+	}
+	return out
+}
+
 // validateWithAPI performs API-dependent validation: RESTMapper scope check and
 // SubjectAccessReview for both the requesting user and the controller service account.
 // verb is the RBAC verb to check ("create" on create/update, "delete" on delete).
@@ -456,6 +470,7 @@ func (v *WorkerResourceTemplateValidator) validateWithAPI(ctx context.Context, w
 			Spec: authorizationv1.SubjectAccessReviewSpec{
 				User:   req.UserInfo.Username,
 				Groups: req.UserInfo.Groups,
+				Extra:  convertUserInfoExtra(req.UserInfo.Extra),
 				ResourceAttributes: &authorizationv1.ResourceAttributes{
 					Namespace: wrt.Namespace,
 					Verb:      verb,


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 

   
<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
<!-- We work best with you when we have accepted the idea first before you code. -->

Pass UserInfo.Extra fields when constructing the SubjectAccessReview for the requesting user in the WorkerResourceTemplate validating webhook.

## Why?
<!-- Tell your future self why have you made these changes -->

Previously, the webhook only forwarded User and Groups to the SAR spec. This omitted the Extra field, which cloud providers like GKE use to carry IAM identity information (e.g. iam.gke.io/user-assertion). Without it, the SAR could not evaluate permissions granted via GKE IAM or GCP group membership, only direct RBAC bindings to a specific username were recognized.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here --> #263

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
deployed to one GKE cluster, people with GKE IAM Admin permission can create/update/delete WorkerResourceTemplate resource without granting Kubernetes built-in RBAC bindings

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
