### PR TITLE
Add helm dependency build step to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,6 +139,9 @@ jobs:
           git commit -m "Bump chart version to $NEW_VERSION [skip ci]"
           git push
 
+      - name: Build chart dependencies
+        run: helm repo add jetstack https://charts.jetstack.io && helm dependency build ./helm/temporal-worker-controller
+
       - name: Package and Push Helm charts
         run: |
           # Use version from previous step


### PR DESCRIPTION
## Summary
- Add `helm dependency build` before `helm package` in the release workflow's helm job
- This fixes the controller Helm chart push which has been failing since cert-manager was added as an optional subchart dependency
- The other helm workflows (`helm.yml`, `helm-validate.yml`, `helm-image-check.yml`) already have this step — `release.yml` was missed

## Context
The v1.5.0, v1.5.1, and v1.5.2 releases all failed to push the controller Helm chart to OCI with:
```
Error: found in Chart.yaml, but missing in charts/ directory: cert-manager
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)