### PR TITLE
deprecate authProxy.enabled value option

### DIFF
--- a/.github/workflows/helm-image-check.yml
+++ b/.github/workflows/helm-image-check.yml
@@ -43,7 +43,6 @@ jobs:
             --set namespace.create=true \
             > /tmp/rendered-namespace.yaml
           helm template test-release helm/temporal-worker-controller \
-            --set authProxy.enabled=false \
             --set metrics.disableAuth=true \
             > /tmp/rendered-no-auth.yaml
 

--- a/.github/workflows/helm-validate.yml
+++ b/.github/workflows/helm-validate.yml
@@ -47,7 +47,6 @@ jobs:
       - name: Template with auth proxy disabled
         run: |
           helm template test-release helm/temporal-worker-controller \
-            --set authProxy.enabled=false \
             --set metrics.disableAuth=true
 
   helm-lint-crds:

--- a/helm/temporal-worker-controller/templates/auth_proxy.yaml
+++ b/helm/temporal-worker-controller/templates/auth_proxy.yaml
@@ -1,4 +1,5 @@
-{{- if .Values.authProxy.enabled -}}
+{{- if .Values.metrics.enabled }}
+{{- if not .Values.metrics.disableAuth -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -62,4 +63,5 @@ spec:
   selector:
     {{- include "temporal-worker-controller.selectorLabels" . | nindent 4 }}
 ---
+{{- end -}}
 {{- end }}

--- a/helm/temporal-worker-controller/templates/manager.yaml
+++ b/helm/temporal-worker-controller/templates/manager.yaml
@@ -91,7 +91,11 @@ spec:
         args:
         - --leader-elect
         {{- if .Values.metrics.enabled }}
+        {{- if .Values.metrics.disableAuth }}
+        - "--metrics-bind-address=:{{ .Values.metrics.port }}"
+        {{- else }}
         - "--metrics-bind-address=127.0.0.1:{{ .Values.metrics.port }}"
+        {{- end }}
         {{- end }}
         - "--health-probe-bind-address=:8081"
         ports:

--- a/helm/temporal-worker-controller/values.schema.json
+++ b/helm/temporal-worker-controller/values.schema.json
@@ -121,7 +121,8 @@
       "properties": {
         "enabled": {
           "type": "boolean",
-          "description": "Whether to enable the auth proxy"
+          "description": "Whether to enable the auth proxy",
+          "deprecated": true
         }
       }
     },

--- a/helm/temporal-worker-controller/values.yaml
+++ b/helm/temporal-worker-controller/values.yaml
@@ -57,9 +57,8 @@ affinity: {}
 # More than one replica is required for high availability.
 replicas: 2
 
-# Opt out of these resources if you want to disable the
-# auth proxy (https://github.com/brancz/kube-rbac-proxy)
-# which protects your /metrics endpoint.
+# deprecated. disable authenticated metrics endpoint access with the
+# metrics.disableAuth value.
 authProxy:
   enabled: true
 
@@ -67,9 +66,19 @@ metrics:
   enabled: true
   port: 8080
   # Set to true if you want your controller-manager to expose the /metrics
-  # endpoint w/o any authn/z. If false, creates an HTTP proxy sidecar container
-  # for the controller manager which performs RBAC authorization against the
-  # Kubernetes API using SubjectAccessReviews.
+  # endpoint w/o any authn/z.
+  #
+  # If false (the default), a kube-rbac-proxy sidecar
+  # (https://github.com/brancz/kube-rbac-proxy) is injected into the manager
+  # pod. It listens on HTTPS port 8443 and proxies to the manager's metrics
+  # endpoint on localhost, authorizing each request via Kubernetes
+  # SubjectAccessReviews. The manager binds metrics to 127.0.0.1 so it is only
+  # reachable through the proxy.
+  #
+  # Set to true when network-level controls already restrict access
+  # (NetworkPolicy, service mesh, same-namespace Prometheus), your scraper
+  # cannot present a bearer token, or simplicity is preferred (e.g.
+  # dev/staging).
   disableAuth: false
 
 namespace:


### PR DESCRIPTION
Marks the `authProxy.enabled` values file option as deprecated and adds documentation to the `metrics.disableAuth` values file option explaining its effect.

Ensures that metrics port binding to localhost (127.0.0.1) only occurs when the auth proxy is enabled (via metrics.disableAuth=true).

Issue #167