### PR TITLE
Fix CEL to actually block deprecated resource create

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Image URL to use all building/pushing image targets
 IMG ?= temporal-worker-controller:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.27.1
+ENVTEST_K8S_VERSION = 1.29.0
 
 MAIN_BRANCH = main
 ALL_TEST_TAGS = test_dep

--- a/api/v1alpha1/deprecated_temporalconnection_types.go
+++ b/api/v1alpha1/deprecated_temporalconnection_types.go
@@ -51,7 +51,7 @@ type TemporalConnectionStatus struct {
 //+kubebuilder:resource:shortName=tconn
 //+kubebuilder:printcolumn:name="Host",type="string",JSONPath=".spec.hostPort",description="Temporal server endpoint"
 //+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Age"
-// +kubebuilder:validation:XValidation:rule="oldSelf != null",message="TemporalConnection is deprecated and cannot be created. Use Connection instead."
+// +kubebuilder:validation:XValidation:rule="oldSelf.hasValue()",message="TemporalConnection is deprecated and cannot be created. Use Connection instead.",optionalOldSelf=true
 // +kubebuilder:deprecatedversion:warning="TemporalConnection is deprecated. Use Connection instead."
 
 // TemporalConnection is the Schema for the temporalconnections API

--- a/api/v1alpha1/deprecated_temporalworkerdeployment_types.go
+++ b/api/v1alpha1/deprecated_temporalworkerdeployment_types.go
@@ -158,7 +158,7 @@ type TemporalWorkerDeploymentStatus struct {
 //+kubebuilder:printcolumn:name="Ramp %",type="number",JSONPath=".status.targetVersion.rampPercentage",description="Ramp percentage"
 //+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Age"
 // +kubebuilder:validation:XValidation:rule="size(self.metadata.name) <= 63",message="name cannot be more than 63 characters"
-// +kubebuilder:validation:XValidation:rule="oldSelf != null",message="TemporalWorkerDeployment is deprecated and cannot be created. Use WorkerDeployment instead."
+// +kubebuilder:validation:XValidation:rule="oldSelf.hasValue()",message="TemporalWorkerDeployment is deprecated and cannot be created. Use WorkerDeployment instead.",optionalOldSelf=true
 // +kubebuilder:deprecatedversion:warning="TemporalWorkerDeployment is deprecated. Use WorkerDeployment instead."
 
 // TemporalWorkerDeployment is the Schema for the temporalworkerdeployments API

--- a/helm/temporal-worker-controller-crds/templates/temporal.io_temporalconnections.yaml
+++ b/helm/temporal-worker-controller-crds/templates/temporal.io_temporalconnections.yaml
@@ -115,7 +115,8 @@ spec:
         x-kubernetes-validations:
         - message: TemporalConnection is deprecated and cannot be created. Use Connection
             instead.
-          rule: oldSelf != null
+          optionalOldSelf: true
+          rule: oldSelf.hasValue()
     served: true
     storage: true
     subresources:

--- a/helm/temporal-worker-controller-crds/templates/temporal.io_temporalworkerdeployments.yaml
+++ b/helm/temporal-worker-controller-crds/templates/temporal.io_temporalworkerdeployments.yaml
@@ -4216,7 +4216,8 @@ spec:
           rule: size(self.metadata.name) <= 63
         - message: TemporalWorkerDeployment is deprecated and cannot be created. Use
             WorkerDeployment instead.
-          rule: oldSelf != null
+          optionalOldSelf: true
+          rule: oldSelf.hasValue()
     served: true
     storage: true
     subresources:


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Without `optionalOldSelf: true`, oldSelf is either present (on update) or rule is skipped (on create).
We want the rule to be enforced on create!
Also, oldSelf != nil doesn't work, must be hasValue()

## Why?
To behave as documented and expected after deprecating the old CRDs

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
In local cluster I tested that you could update an existing object, but that you could not create one.
Also tested with the old rule and saw that it did not actually block creation.

Note: regardless of the CEL rule, all operations (get, delete, describe, etc) print this warning, which is nice:
```
Warning: TemporalConnection is deprecated. Use Connection instead.
```

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
