### PR TITLE
Add imagePullSecrets support for private registry authentication (#322)

### DIFF
--- a/helm/temporal-worker-controller/templates/manager.yaml
+++ b/helm/temporal-worker-controller/templates/manager.yaml
@@ -55,7 +55,7 @@ spec:
         seccompProfile:
           type: RuntimeDefault
         {{- end }}
-      {{- with .Values.image.imagePullSecrets }}
+      {{- with .Values.image.pullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/helm/temporal-worker-controller/templates/manager.yaml
+++ b/helm/temporal-worker-controller/templates/manager.yaml
@@ -55,6 +55,10 @@ spec:
         seccompProfile:
           type: RuntimeDefault
         {{- end }}
+      {{- with .Values.image.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: manager
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion)}}"

--- a/helm/temporal-worker-controller/values.schema.json
+++ b/helm/temporal-worker-controller/values.schema.json
@@ -16,8 +16,28 @@
         },
         "pullPolicy": {
           "type": "string",
-          "enum": ["Always", "IfNotPresent", "Never"],
+          "enum": [
+            "Always",
+            "IfNotPresent",
+            "Never"
+          ],
           "description": "Container image pull policy"
+        },
+        "imagePullSecrets": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Name of the secret containing registry credentials"
+              }
+            },
+            "required": [
+              "name"
+            ]
+          },
+          "description": "List of secrets for pulling images from private registries"
         }
       }
     },
@@ -92,7 +112,10 @@
           "description": "Whether to create a ServiceAccount"
         },
         "name": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "The name of the ServiceAccount to use. If null, a name will be generated using the release name."
         }
       }
@@ -217,4 +240,4 @@
       "type": "number"
     }
   }
-} 
+}

--- a/helm/temporal-worker-controller/values.schema.json
+++ b/helm/temporal-worker-controller/values.schema.json
@@ -23,7 +23,7 @@
           ],
           "description": "Container image pull policy"
         },
-        "imagePullSecrets": {
+        "pullSecrets": {
           "type": "array",
           "items": {
             "type": "object",

--- a/helm/temporal-worker-controller/values.yaml
+++ b/helm/temporal-worker-controller/values.yaml
@@ -2,6 +2,7 @@ image:
   repository: temporalio/temporal-worker-controller
   tag: "" # Defaults to Chart.appVersion if not specified
   pullPolicy: IfNotPresent
+  imagePullSecrets: []
 
 podAnnotations: {}
   # Additional pod annotations can be added here

--- a/helm/temporal-worker-controller/values.yaml
+++ b/helm/temporal-worker-controller/values.yaml
@@ -2,7 +2,7 @@ image:
   repository: temporalio/temporal-worker-controller
   tag: "" # Defaults to Chart.appVersion if not specified
   pullPolicy: IfNotPresent
-  imagePullSecrets: []
+  pullSecrets: []
 
 podAnnotations: {}
   # Additional pod annotations can be added here


### PR DESCRIPTION
### Why
Fixes #322. When using a mirrored or private container registry, users need to specify `imagePullSecrets`  to authenticate. The chart currently has no `imagePullSecrets` value exposed.

### What

* Add `imagePullSecrets: []` to the `values.yaml`
* Update `values.schema.json`
* Update `manager.yaml` to render `imagePullSecrets` in pod spec
