### PR TITLE
feat(wrt): auto-inject KEDA Temporal trigger metadata for per-version ScaledObjects

### DIFF
--- a/api/v1alpha1/workerresourcetemplate_webhook.go
+++ b/api/v1alpha1/workerresourcetemplate_webhook.go
@@ -342,8 +342,8 @@ func checkTemporalTriggerMetadataNotSet(spec map[string]interface{}, path *field
 		if !ok {
 			continue
 		}
-		triggerType, _ := trigger["type"].(string)
-		if triggerType != "temporal" {
+		triggerType, ok := trigger["type"].(string)
+		if !ok || triggerType != "temporal" {
 			continue
 		}
 		metadata, ok := trigger["metadata"].(map[string]interface{})

--- a/api/v1alpha1/workerresourcetemplate_webhook.go
+++ b/api/v1alpha1/workerresourcetemplate_webhook.go
@@ -313,9 +313,59 @@ func validateWorkerResourceTemplateSpec(spec WorkerResourceTemplateSpec, allowed
 		// the controller generates the correct per-version values at render time.
 		// User labels (e.g. task_type: "Activity") are allowed alongside the controller-owned keys.
 		checkMetricSelectorLabelsNotSet(innerSpec, innerSpecPath, &allErrs)
+
+		// 8. triggers[*].metadata.workerDeploymentName / workerDeploymentBuildId
+		// (KEDA ScaledObject): the controller owns these for triggers of type "temporal" so
+		// each per-version ScaledObject queries the correct Temporal-server worker deployment.
+		// Allow empty-string opt-in ("") and reject any other value.
+		checkTemporalTriggerMetadataNotSet(innerSpec, innerSpecPath, &allErrs)
 	}
 
 	return warnings, allErrs
+}
+
+// checkTemporalTriggerMetadataNotSet validates that, for each KEDA trigger of type "temporal"
+// in spec.triggers, the controller-owned metadata keys (workerDeploymentName,
+// workerDeploymentBuildId) are either absent or set to the empty-string opt-in sentinel.
+// A non-empty value is rejected — the controller fills these per-version at render time
+// and a hardcoded value would point at the wrong worker deployment / build.
+// Non-temporal triggers (prometheus, cron, etc.) are not validated.
+func checkTemporalTriggerMetadataNotSet(spec map[string]interface{}, path *field.Path, allErrs *field.ErrorList) {
+	triggers, ok := spec["triggers"].([]interface{})
+	if !ok {
+		return
+	}
+	triggersPath := path.Child("triggers")
+	for i, t := range triggers {
+		trigger, ok := t.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		triggerType, _ := trigger["type"].(string)
+		if triggerType != "temporal" {
+			continue
+		}
+		metadata, ok := trigger["metadata"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		triggerPath := triggersPath.Index(i).Child("metadata")
+		for _, key := range []string{"workerDeploymentName", "workerDeploymentBuildId"} {
+			val, present := metadata[key]
+			if !present {
+				continue
+			}
+			s, isString := val.(string)
+			if !isString || s != "" {
+				*allErrs = append(*allErrs, field.Forbidden(
+					triggerPath.Child(key),
+					"if "+key+" is present on a temporal trigger, the controller owns it and "+
+						"will set it to the per-version value; set it to \"\" to opt in to auto-injection, "+
+						"or remove it entirely if you do not need per-version trigger metadata",
+				))
+			}
+		}
+	}
 }
 
 // checkScaleTargetRefNotSet recursively traverses obj looking for any scaleTargetRef that is

--- a/api/v1alpha1/workerresourcetemplate_webhook.go
+++ b/api/v1alpha1/workerresourcetemplate_webhook.go
@@ -326,9 +326,10 @@ func validateWorkerResourceTemplateSpec(spec WorkerResourceTemplateSpec, allowed
 
 // checkTemporalTriggerMetadataNotSet validates that, for each KEDA trigger of type "temporal"
 // in spec.triggers, the controller-owned metadata keys (workerDeploymentName,
-// workerDeploymentBuildId) are either absent or set to the empty-string opt-in sentinel.
-// A non-empty value is rejected — the controller fills these per-version at render time
-// and a hardcoded value would point at the wrong worker deployment / build.
+// workerDeploymentBuildId, namespace) are either absent or set to the empty-string opt-in
+// sentinel. A non-empty value is rejected — the controller fills these at render time from
+// the WorkerDeployment's connection / per-version state, and a hardcoded value would point
+// at the wrong worker deployment / build / Temporal namespace.
 // Non-temporal triggers (prometheus, cron, etc.) are not validated.
 func checkTemporalTriggerMetadataNotSet(spec map[string]interface{}, path *field.Path, allErrs *field.ErrorList) {
 	triggers, ok := spec["triggers"].([]interface{})
@@ -350,7 +351,7 @@ func checkTemporalTriggerMetadataNotSet(spec map[string]interface{}, path *field
 			continue
 		}
 		triggerPath := triggersPath.Index(i).Child("metadata")
-		for _, key := range []string{"workerDeploymentName", "workerDeploymentBuildId"} {
+		for _, key := range []string{"workerDeploymentName", "workerDeploymentBuildId", "namespace"} {
 			val, present := metadata[key]
 			if !present {
 				continue
@@ -360,8 +361,8 @@ func checkTemporalTriggerMetadataNotSet(spec map[string]interface{}, path *field
 				*allErrs = append(*allErrs, field.Forbidden(
 					triggerPath.Child(key),
 					"if "+key+" is present on a temporal trigger, the controller owns it and "+
-						"will set it to the per-version value; set it to \"\" to opt in to auto-injection, "+
-						"or remove it entirely if you do not need per-version trigger metadata",
+						"will set it to the per-version or per-connection value; set it to \"\" to opt in "+
+						"to auto-injection, or remove it entirely if you do not need it",
 				))
 			}
 		}

--- a/api/v1alpha1/workerresourcetemplate_webhook.go
+++ b/api/v1alpha1/workerresourcetemplate_webhook.go
@@ -316,22 +316,23 @@ func validateWorkerResourceTemplateSpec(spec WorkerResourceTemplateSpec, allowed
 
 		// 8. triggers[*].metadata.workerDeploymentName / workerDeploymentBuildId
 		// (KEDA ScaledObject): the controller owns these for triggers of type "temporal" so
-		// each per-version ScaledObject queries the correct Temporal-server worker deployment.
-		// Allow empty-string opt-in ("") and reject any other value.
-		checkTemporalTriggerMetadataNotSet(innerSpec, innerSpecPath, &allErrs)
+		// each per-version ScaledObject queries the correct Temporal Worker Deployment Version
+		// (workerDeploymentName + workerDeploymentBuildId). Allow empty-string opt-in ("") and
+		// reject any other value.
+		checkKEDATriggerMetadata(innerSpec, innerSpecPath, &allErrs)
 	}
 
 	return warnings, allErrs
 }
 
-// checkTemporalTriggerMetadataNotSet validates that, for each KEDA trigger of type "temporal"
+// checkKEDATriggerMetadata validates that, for each KEDA trigger of type "temporal"
 // in spec.triggers, the controller-owned metadata keys (workerDeploymentName,
 // workerDeploymentBuildId, namespace) are either absent or set to the empty-string opt-in
 // sentinel. A non-empty value is rejected — the controller fills these at render time from
 // the WorkerDeployment's connection / per-version state, and a hardcoded value would point
 // at the wrong worker deployment / build / Temporal namespace.
 // Non-temporal triggers (prometheus, cron, etc.) are not validated.
-func checkTemporalTriggerMetadataNotSet(spec map[string]interface{}, path *field.Path, allErrs *field.ErrorList) {
+func checkKEDATriggerMetadata(spec map[string]interface{}, path *field.Path, allErrs *field.ErrorList) {
 	triggers, ok := spec["triggers"].([]interface{})
 	if !ok {
 		return
@@ -360,7 +361,7 @@ func checkTemporalTriggerMetadataNotSet(spec map[string]interface{}, path *field
 			if !isString || s != "" {
 				*allErrs = append(*allErrs, field.Forbidden(
 					triggerPath.Child(key),
-					"if "+key+" is present on a temporal trigger, the controller owns it and "+
+					"if "+key+" is present on a KEDA ScaledObject temporal trigger, the controller owns it and "+
 						"will set it to the per-version or per-connection value; set it to \"\" to opt in "+
 						"to auto-injection, or remove it entirely if you do not need it",
 				))

--- a/api/v1alpha1/workerresourcetemplate_webhook_test.go
+++ b/api/v1alpha1/workerresourcetemplate_webhook_test.go
@@ -7,14 +7,13 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	temporaliov1alpha1 "github.com/temporalio/temporal-worker-controller/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-
-	temporaliov1alpha1 "github.com/temporalio/temporal-worker-controller/api/v1alpha1"
 )
 
 // newWRT builds a WorkerResourceTemplate with an arbitrary embedded object spec.

--- a/api/v1alpha1/workerresourcetemplate_webhook_test.go
+++ b/api/v1alpha1/workerresourcetemplate_webhook_test.go
@@ -7,13 +7,14 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	temporaliov1alpha1 "github.com/temporalio/temporal-worker-controller/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	temporaliov1alpha1 "github.com/temporalio/temporal-worker-controller/api/v1alpha1"
 )
 
 // newWRT builds a WorkerResourceTemplate with an arbitrary embedded object spec.
@@ -457,7 +458,7 @@ func scaledObjectTemplateWithTemporalTrigger(metadataOverrides map[string]interf
 		"apiVersion": "keda.sh/v1alpha1",
 		"kind":       "ScaledObject",
 		"spec": map[string]interface{}{
-			"scaleTargetRef": map[string]interface{}{}, // opt-in
+			"scaleTargetRef":  map[string]interface{}{}, // opt-in
 			"minReplicaCount": float64(1),
 			"maxReplicaCount": float64(10),
 			"triggers": []interface{}{

--- a/api/v1alpha1/workerresourcetemplate_webhook_test.go
+++ b/api/v1alpha1/workerresourcetemplate_webhook_test.go
@@ -482,19 +482,19 @@ func TestWorkerResourceTemplate_ValidateCreate_TemporalTriggerMetadata(t *testin
 			obj: newWRT("keda-bad-name", "my-worker", scaledObjectTemplateWithTemporalTrigger(map[string]interface{}{
 				"workerDeploymentName": "some-other-name",
 			})),
-			errorMsg: "if workerDeploymentName is present on a temporal trigger, the controller owns it",
+			errorMsg: "if workerDeploymentName is present on a KEDA ScaledObject temporal trigger, the controller owns it",
 		},
 		"non-empty workerDeploymentBuildId is rejected": {
 			obj: newWRT("keda-bad-build", "my-worker", scaledObjectTemplateWithTemporalTrigger(map[string]interface{}{
 				"workerDeploymentBuildId": "abc123",
 			})),
-			errorMsg: "if workerDeploymentBuildId is present on a temporal trigger, the controller owns it",
+			errorMsg: "if workerDeploymentBuildId is present on a KEDA ScaledObject temporal trigger, the controller owns it",
 		},
 		"non-empty namespace is rejected": {
 			obj: newWRT("keda-bad-namespace", "my-worker", scaledObjectTemplateWithTemporalTrigger(map[string]interface{}{
 				"namespace": "some-other-temporal-ns",
 			})),
-			errorMsg: "if namespace is present on a temporal trigger, the controller owns it",
+			errorMsg: "if namespace is present on a KEDA ScaledObject temporal trigger, the controller owns it",
 		},
 		"non-temporal trigger with same keys is allowed (validation only targets temporal triggers)": {
 			obj: newWRT("keda-prom-trigger", "my-worker", map[string]interface{}{

--- a/api/v1alpha1/workerresourcetemplate_webhook_test.go
+++ b/api/v1alpha1/workerresourcetemplate_webhook_test.go
@@ -445,7 +445,7 @@ func newValidatorNoAPIWithKEDA() *temporaliov1alpha1.WorkerResourceTemplateValid
 func scaledObjectTemplateWithTemporalTrigger(metadataOverrides map[string]interface{}) map[string]interface{} {
 	metadata := map[string]interface{}{
 		"endpoint":                "us-east-1.aws.api.temporal.io:7233",
-		"namespace":               "default",
+		"namespace":               "", // opt-in sentinel — controller injects from connection
 		"taskQueue":               "my-tq",
 		"workerDeploymentName":    "", // opt-in sentinel
 		"workerDeploymentBuildId": "", // opt-in sentinel
@@ -489,6 +489,12 @@ func TestWorkerResourceTemplate_ValidateCreate_TemporalTriggerMetadata(t *testin
 				"workerDeploymentBuildId": "abc123",
 			})),
 			errorMsg: "if workerDeploymentBuildId is present on a temporal trigger, the controller owns it",
+		},
+		"non-empty namespace is rejected": {
+			obj: newWRT("keda-bad-namespace", "my-worker", scaledObjectTemplateWithTemporalTrigger(map[string]interface{}{
+				"namespace": "some-other-temporal-ns",
+			})),
+			errorMsg: "if namespace is present on a temporal trigger, the controller owns it",
 		},
 		"non-temporal trigger with same keys is allowed (validation only targets temporal triggers)": {
 			obj: newWRT("keda-prom-trigger", "my-worker", map[string]interface{}{

--- a/api/v1alpha1/workerresourcetemplate_webhook_test.go
+++ b/api/v1alpha1/workerresourcetemplate_webhook_test.go
@@ -423,6 +423,114 @@ func TestWorkerResourceTemplate_ValidateCreate(t *testing.T) {
 	}
 }
 
+// newValidatorNoAPIWithKEDA mirrors newValidatorNoAPI but additionally allows the
+// KEDA ScaledObject kind, so tests of KEDA-specific validation can reach the relevant
+// check without being rejected by the allow-list.
+func newValidatorNoAPIWithKEDA() *temporaliov1alpha1.WorkerResourceTemplateValidator {
+	return &temporaliov1alpha1.WorkerResourceTemplateValidator{
+		Client: fake.NewClientBuilder().Build(),
+		RESTMapper: newFakeRESTMapper(
+			schema.GroupVersionKind{Group: "autoscaling", Version: "v2", Kind: "HorizontalPodAutoscaler"},
+			schema.GroupVersionKind{Group: "policy", Version: "v1", Kind: "PodDisruptionBudget"},
+			schema.GroupVersionKind{Group: "keda.sh", Version: "v1alpha1", Kind: "ScaledObject"},
+		),
+		AllowedKinds: []string{"HorizontalPodAutoscaler", "PodDisruptionBudget", "ScaledObject"},
+	}
+}
+
+// scaledObjectTemplateWithTemporalTrigger builds a minimal KEDA ScaledObject template
+// where the user can set their own trigger metadata values; auto-injection placeholders
+// for workerDeploymentName / workerDeploymentBuildId default to the empty-string sentinel
+// unless overridden by the caller.
+func scaledObjectTemplateWithTemporalTrigger(metadataOverrides map[string]interface{}) map[string]interface{} {
+	metadata := map[string]interface{}{
+		"endpoint":                "us-east-1.aws.api.temporal.io:7233",
+		"namespace":               "default",
+		"taskQueue":               "my-tq",
+		"workerDeploymentName":    "", // opt-in sentinel
+		"workerDeploymentBuildId": "", // opt-in sentinel
+	}
+	for k, v := range metadataOverrides {
+		metadata[k] = v
+	}
+	return map[string]interface{}{
+		"apiVersion": "keda.sh/v1alpha1",
+		"kind":       "ScaledObject",
+		"spec": map[string]interface{}{
+			"scaleTargetRef": map[string]interface{}{}, // opt-in
+			"minReplicaCount": float64(1),
+			"maxReplicaCount": float64(10),
+			"triggers": []interface{}{
+				map[string]interface{}{
+					"type":     "temporal",
+					"metadata": metadata,
+				},
+			},
+		},
+	}
+}
+
+func TestWorkerResourceTemplate_ValidateCreate_TemporalTriggerMetadata(t *testing.T) {
+	tests := map[string]struct {
+		obj      runtime.Object
+		errorMsg string
+	}{
+		"empty workerDeploymentName + workerDeploymentBuildId opt-in is valid": {
+			obj: newWRT("keda-opt-in", "my-worker", scaledObjectTemplateWithTemporalTrigger(nil)),
+		},
+		"non-empty workerDeploymentName is rejected": {
+			obj: newWRT("keda-bad-name", "my-worker", scaledObjectTemplateWithTemporalTrigger(map[string]interface{}{
+				"workerDeploymentName": "some-other-name",
+			})),
+			errorMsg: "if workerDeploymentName is present on a temporal trigger, the controller owns it",
+		},
+		"non-empty workerDeploymentBuildId is rejected": {
+			obj: newWRT("keda-bad-build", "my-worker", scaledObjectTemplateWithTemporalTrigger(map[string]interface{}{
+				"workerDeploymentBuildId": "abc123",
+			})),
+			errorMsg: "if workerDeploymentBuildId is present on a temporal trigger, the controller owns it",
+		},
+		"non-temporal trigger with same keys is allowed (validation only targets temporal triggers)": {
+			obj: newWRT("keda-prom-trigger", "my-worker", map[string]interface{}{
+				"apiVersion": "keda.sh/v1alpha1",
+				"kind":       "ScaledObject",
+				"spec": map[string]interface{}{
+					"scaleTargetRef":  map[string]interface{}{},
+					"minReplicaCount": float64(1),
+					"maxReplicaCount": float64(10),
+					"triggers": []interface{}{
+						map[string]interface{}{
+							"type": "prometheus",
+							"metadata": map[string]interface{}{
+								"serverAddress":           "http://prom",
+								"workerDeploymentName":    "anything-goes",
+								"workerDeploymentBuildId": "anything-goes",
+							},
+						},
+					},
+				},
+			}),
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+			v := newValidatorNoAPIWithKEDA()
+
+			warnings, err := v.ValidateCreate(ctx, tc.obj)
+
+			if tc.errorMsg != "" {
+				require.Error(t, err, "expected an error containing %q", tc.errorMsg)
+				assert.Contains(t, err.Error(), tc.errorMsg)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Nil(t, warnings)
+		})
+	}
+}
+
 func TestWorkerResourceTemplate_ValidateUpdate_Immutability(t *testing.T) {
 	tests := map[string]struct {
 		oldWorkerDeploymentRef string

--- a/internal/k8s/deployments.go
+++ b/internal/k8s/deployments.go
@@ -30,13 +30,19 @@ const (
 	// BuildIDLabel is the label that identifies the build ID for a deployment
 	BuildIDLabel = "temporal.io/build-id"
 	// WorkerDeploymentNameLabel identifies Deployments managed for a TemporalWorkerDeployment.
-	WorkerDeploymentNameLabel     = "temporal.io/deployment-name"
+	WorkerDeploymentNameLabel = "temporal.io/deployment-name"
+	// WorkerDeploymentNameSeparator joins the K8s namespace and the WorkerDeployment resource
+	// name to form the Temporal-server-side worker deployment name (namespace/wdName).
 	WorkerDeploymentNameSeparator = "/"
-	ResourceNameSeparator         = "-"
-	MaxBuildIDLen                 = 63
-	MaxDeploymentNameLen          = 47
-	ConnectionSpecHashAnnotation  = "temporal.io/connection-spec-hash"
-	PodTemplateSpecHashAnnotation = "temporal.io/pod-template-spec-hash"
+	// WorkerDeploymentNameSeparatorK8sLabelCompliant is the substitute used when the
+	// Temporal-server worker deployment name needs to be stored in a Kubernetes label value
+	// (which disallows "/"). See cleanDeploymentNameForK8sLabelValue.
+	WorkerDeploymentNameSeparatorK8sLabelCompliant = "_"
+	ResourceNameSeparator                          = "-"
+	MaxBuildIDLen                                  = 63
+	MaxDeploymentNameLen                           = 47
+	ConnectionSpecHashAnnotation                   = "temporal.io/connection-spec-hash"
+	PodTemplateSpecHashAnnotation                  = "temporal.io/pod-template-spec-hash"
 )
 
 // DeploymentState represents the Kubernetes state of all deployments for a temporal worker deployment
@@ -139,8 +145,12 @@ func ComputeBuildID(w *temporaliov1alpha1.WorkerDeployment) string {
 
 // ComputeWorkerDeploymentName generates the base worker deployment name
 func ComputeWorkerDeploymentName(w *temporaliov1alpha1.WorkerDeployment) string {
+	return computeWorkerDeploymentName(w.GetNamespace(), w.GetName())
+}
+
+func computeWorkerDeploymentName(k8sNamespace, workerDeploymentResourceName string) string {
 	// Use the name and namespace to form the worker deployment name
-	return w.GetNamespace() + WorkerDeploymentNameSeparator + w.GetName()
+	return k8sNamespace + WorkerDeploymentNameSeparator + workerDeploymentResourceName
 }
 
 // ComputeVersionedDeploymentName generates a name for a versioned deployment
@@ -190,6 +200,10 @@ func CleanStringForDNS(s string) string {
 	re := regexp.MustCompile(`[^a-zA-Z0-9-]+`)
 	// Lowercase to ensure RFC 1123 DNS label compliance for Kubernetes resource names.
 	return strings.ToLower(re.ReplaceAllString(s, ResourceNameSeparator))
+}
+
+func cleanDeploymentNameForK8sLabelValue(s string) string {
+	return strings.ReplaceAll(s, WorkerDeploymentNameSeparator, WorkerDeploymentNameSeparatorK8sLabelCompliant)
 }
 
 // Build ID is used as a label in k8s, and as the build ID for

--- a/internal/k8s/deployments.go
+++ b/internal/k8s/deployments.go
@@ -15,14 +15,15 @@ import (
 	"strings"
 
 	"github.com/distribution/reference"
-	temporaliov1alpha1 "github.com/temporalio/temporal-worker-controller/api/v1alpha1"
-	"github.com/temporalio/temporal-worker-controller/internal/controller/k8s.io/utils"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	temporaliov1alpha1 "github.com/temporalio/temporal-worker-controller/api/v1alpha1"
+	"github.com/temporalio/temporal-worker-controller/internal/controller/k8s.io/utils"
 )
 
 const (

--- a/internal/k8s/deployments.go
+++ b/internal/k8s/deployments.go
@@ -15,15 +15,14 @@ import (
 	"strings"
 
 	"github.com/distribution/reference"
+	temporaliov1alpha1 "github.com/temporalio/temporal-worker-controller/api/v1alpha1"
+	"github.com/temporalio/temporal-worker-controller/internal/controller/k8s.io/utils"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	temporaliov1alpha1 "github.com/temporalio/temporal-worker-controller/api/v1alpha1"
-	"github.com/temporalio/temporal-worker-controller/internal/controller/k8s.io/utils"
 )
 
 const (

--- a/internal/k8s/workerresourcetemplates.go
+++ b/internal/k8s/workerresourcetemplates.go
@@ -7,10 +7,11 @@ import (
 	"fmt"
 	"strings"
 
-	temporaliov1alpha1 "github.com/temporalio/temporal-worker-controller/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	temporaliov1alpha1 "github.com/temporalio/temporal-worker-controller/api/v1alpha1"
 )
 
 // RenderedHashLen is the number of hex characters used for rendered-object hashes stored in
@@ -251,8 +252,8 @@ func appendTemporalTriggerMetadata(spec map[string]interface{}, twdName, buildID
 		if !ok {
 			continue
 		}
-		triggerType, _ := trigger["type"].(string)
-		if triggerType != "temporal" {
+		triggerType, ok := trigger["type"].(string)
+		if !ok || triggerType != "temporal" {
 			continue
 		}
 		metadata, ok := trigger["metadata"].(map[string]interface{})

--- a/internal/k8s/workerresourcetemplates.go
+++ b/internal/k8s/workerresourcetemplates.go
@@ -7,11 +7,10 @@ import (
 	"fmt"
 	"strings"
 
+	temporaliov1alpha1 "github.com/temporalio/temporal-worker-controller/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-
-	temporaliov1alpha1 "github.com/temporalio/temporal-worker-controller/api/v1alpha1"
 )
 
 // RenderedHashLen is the number of hex characters used for rendered-object hashes stored in

--- a/internal/k8s/workerresourcetemplates.go
+++ b/internal/k8s/workerresourcetemplates.go
@@ -99,11 +99,12 @@ func RenderWorkerResourceTemplate(
 		"temporal_namespace":              temporalNamespace,
 	}
 
-	// Step 2: auto-inject scaleTargetRef, selector.matchLabels, and metric selector labels.
-	// NestedFieldNoCopy returns a live reference so mutations are reflected in obj.Object directly.
+	// Step 2: auto-inject scaleTargetRef, selector.matchLabels, metric selector labels,
+	// and KEDA Temporal trigger metadata. NestedFieldNoCopy returns a live reference so
+	// mutations are reflected in obj.Object directly.
 	if specRaw, ok, _ := unstructured.NestedFieldNoCopy(obj.Object, "spec"); ok {
 		if spec, ok := specRaw.(map[string]interface{}); ok {
-			autoInjectFields(spec, deployment.Name, selectorLabels, metricSelectorLabels)
+			autoInjectFields(spec, deployment.Name, twdName, buildID, selectorLabels, metricSelectorLabels)
 		}
 	}
 
@@ -152,9 +153,15 @@ func RenderWorkerResourceTemplate(
 //     matchLabels is present (including {}). User labels like task_type coexist.
 //     If matchLabels is absent, no injection occurs for that metric entry.
 //
+//   - spec.triggers[*].metadata (KEDA ScaledObject): for triggers of type "temporal",
+//     workerDeploymentName and workerDeploymentBuildId are set whenever the key is
+//     present in metadata (including empty string). Required by KEDA's Temporal scaler
+//     (kedacore/keda#7672) for per-version backlog scaling against Worker Deployment
+//     Versioning.
+//
 //   - scaleTargetRef: injected anywhere in the spec tree when {} (empty), via
 //     injectScaleTargetRefRecursive. Unambiguous across all supported resource types.
-func autoInjectFields(spec map[string]interface{}, deploymentName string, podSelectorLabels map[string]string, metricSelectorLabels map[string]string) {
+func autoInjectFields(spec map[string]interface{}, deploymentName, twdName, buildID string, podSelectorLabels map[string]string, metricSelectorLabels map[string]string) {
 	// spec.selector.matchLabels: {} opt-in sentinel.
 	if sel, ok := spec["selector"].(map[string]interface{}); ok {
 		if isEmptyMap(sel["matchLabels"]) {
@@ -166,6 +173,9 @@ func autoInjectFields(spec map[string]interface{}, deploymentName string, podSel
 	if len(metricSelectorLabels) > 0 {
 		appendMetricsMatchLabelSelector(spec, metricSelectorLabels)
 	}
+
+	// triggers[*].metadata: inject KEDA Temporal scaler version identifiers when present.
+	appendTemporalTriggerMetadata(spec, twdName, buildID)
 
 	// scaleTargetRef: inject anywhere in the spec tree.
 	injectScaleTargetRefRecursive(spec, deploymentName)
@@ -204,6 +214,43 @@ func appendMetricsMatchLabelSelector(spec map[string]interface{}, metricSelector
 				existing[k] = v
 			}
 			_ = unstructured.SetNestedStringMap(sel, existing, "matchLabels")
+		}
+	}
+}
+
+// appendTemporalTriggerMetadata walks spec.triggers[*] and, for any KEDA trigger
+// of type "temporal", sets workerDeploymentName and workerDeploymentBuildId in its
+// metadata map. Injection is opt-in: only keys already present in metadata are
+// overwritten, mirroring the matchLabels merge pattern used elsewhere in this file.
+// Users opt a template into per-version injection by writing the placeholder keys
+// (any string value, typically "") in their WorkerResourceTemplate spec.
+//
+// Required by KEDA's Temporal scaler (kedacore/keda#7672) for per-version backlog
+// scaling against Temporal's Worker Deployment Versioning model. Non-temporal
+// triggers in the same ScaledObject are untouched.
+func appendTemporalTriggerMetadata(spec map[string]interface{}, twdName, buildID string) {
+	triggers, ok := spec["triggers"].([]interface{})
+	if !ok {
+		return
+	}
+	for _, t := range triggers {
+		trigger, ok := t.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		triggerType, _ := trigger["type"].(string)
+		if triggerType != "temporal" {
+			continue
+		}
+		metadata, ok := trigger["metadata"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if _, present := metadata["workerDeploymentName"]; present {
+			metadata["workerDeploymentName"] = twdName
+		}
+		if _, present := metadata["workerDeploymentBuildId"]; present {
+			metadata["workerDeploymentBuildId"] = buildID
 		}
 	}
 }

--- a/internal/k8s/workerresourcetemplates.go
+++ b/internal/k8s/workerresourcetemplates.go
@@ -40,7 +40,7 @@ const (
 )
 
 // ComputeWorkerResourceTemplateName generates a deterministic, DNS-safe name for the worker resource template
-// instance corresponding to a given (twdName, wrtName, buildID) triple.
+// instance corresponding to a given (wdName, wrtName, buildID) triple.
 //
 // The name has the form:
 //
@@ -50,16 +50,16 @@ const (
 // capping occurs. This guarantees that two different triples — including triples that
 // differ only in the buildID — always produce different names, even if the human-readable
 // prefix is truncated. The buildID is therefore always uniquely represented via the hash,
-// regardless of how long twdName or wrtName are.
-func ComputeWorkerResourceTemplateName(twdName, wrtName, buildID string) string {
+// regardless of how long wdName or wrtName are.
+func ComputeWorkerResourceTemplateName(wdName, wrtName, buildID string) string {
 	// Hash the full triple first, before any truncation.
-	h := sha256.Sum256([]byte(twdName + wrtName + buildID))
+	h := sha256.Sum256([]byte(wdName + wrtName + buildID))
 	hashSuffix := hex.EncodeToString(h[:workerResourceTemplateHashLen/2]) // 4 bytes → 8 hex chars
 
 	// Build the human-readable prefix and truncate so the total fits in maxLen.
 	// suffixLen = len("-") + workerResourceTemplateHashLen
 	const suffixLen = 1 + workerResourceTemplateHashLen
-	raw := CleanStringForDNS(twdName + ResourceNameSeparator + wrtName + ResourceNameSeparator + buildID)
+	raw := CleanStringForDNS(wdName + ResourceNameSeparator + wrtName + ResourceNameSeparator + buildID)
 	prefix := TruncateString(raw, workerResourceTemplateMaxNameLen-suffixLen)
 	// Trim any trailing separator that results from truncating mid-segment.
 	prefix = strings.TrimRight(prefix, ResourceNameSeparator)
@@ -86,15 +86,20 @@ func RenderWorkerResourceTemplate(
 		return nil, fmt.Errorf("failed to unmarshal spec.template: %w", err)
 	}
 
-	twdName := wrt.Spec.EffectiveWorkerDeploymentName()
-	selectorLabels := ComputeSelectorLabels(twdName, buildID)
+	// The name of the Worker Deployment Kubernetes resource
+	wdName := wrt.Spec.EffectiveWorkerDeploymentName()
+
+	// The name of the Worker Deployment in Temporal Server, prefixed by the Kubernetes namespace of the resource
+	twdName := computeWorkerDeploymentName(wrt.Namespace, wdName)
+
+	selectorLabels := ComputeSelectorLabels(wdName, buildID)
 
 	// Labels the controller appends to every metrics[*].external.metric.selector.matchLabels
 	// that is present in the template. These identify the exact per-version Prometheus series.
 	// Ordering is not a concern: matchLabels is a map; encoding/json serialises map keys in
 	// sorted order, so ComputeRenderedObjectHash is deterministic regardless of insertion order.
 	metricSelectorLabels := map[string]string{
-		"temporal_worker_deployment_name": wrt.Namespace + "_" + twdName,
+		"temporal_worker_deployment_name": cleanDeploymentNameForK8sLabelValue(twdName),
 		"temporal_worker_build_id":        buildID,
 		"temporal_namespace":              temporalNamespace,
 	}

--- a/internal/k8s/workerresourcetemplates.go
+++ b/internal/k8s/workerresourcetemplates.go
@@ -225,10 +225,16 @@ func appendMetricsMatchLabelSelector(spec map[string]interface{}, metricSelector
 
 // appendTemporalTriggerMetadata walks spec.triggers[*] and, for any KEDA trigger
 // of type "temporal", sets workerDeploymentName and workerDeploymentBuildId in its
-// metadata map. Injection is opt-in: only keys already present in metadata are
-// overwritten, mirroring the matchLabels merge pattern used elsewhere in this file.
-// Users opt a template into per-version injection by writing the placeholder keys
-// (any string value, typically "") in their WorkerResourceTemplate spec.
+// metadata map. Injection is opt-in via the empty-string sentinel, mirroring the
+// scaleTargetRef {} sentinel pattern: absent = no injection; present-and-empty = inject;
+// present-and-non-empty is rejected by the WorkerResourceTemplate validating webhook
+// (defense in depth — if a non-empty value reaches the runtime, it is left untouched
+// rather than silently overwritten).
+//
+// twdName must be the fully-qualified Temporal-server Worker Deployment name
+// (computeWorkerDeploymentName(k8sNamespace, wdName)) — that's what workers register
+// with at Temporal Cloud and what KEDA's scaler needs to query backlog for a specific
+// version.
 //
 // Required by KEDA's Temporal scaler (kedacore/keda#7672) for per-version backlog
 // scaling against Temporal's Worker Deployment Versioning model. Non-temporal
@@ -251,13 +257,21 @@ func appendTemporalTriggerMetadata(spec map[string]interface{}, twdName, buildID
 		if !ok {
 			continue
 		}
-		if _, present := metadata["workerDeploymentName"]; present {
+		if isEmptyString(metadata["workerDeploymentName"]) {
 			metadata["workerDeploymentName"] = twdName
 		}
-		if _, present := metadata["workerDeploymentBuildId"]; present {
+		if isEmptyString(metadata["workerDeploymentBuildId"]) {
 			metadata["workerDeploymentBuildId"] = buildID
 		}
 	}
+}
+
+// isEmptyString returns true if v is a string with no characters. The trigger-metadata
+// injection mirrors scaleTargetRef's isEmptyMap sentinel pattern but for string fields,
+// since KEDA's trigger metadata is a map of strings.
+func isEmptyString(v interface{}) bool {
+	s, ok := v.(string)
+	return ok && s == ""
 }
 
 // injectScaleTargetRefRecursive recursively traverses obj and injects scaleTargetRef

--- a/internal/k8s/workerresourcetemplates.go
+++ b/internal/k8s/workerresourcetemplates.go
@@ -90,7 +90,7 @@ func RenderWorkerResourceTemplate(
 	wdName := wrt.Spec.EffectiveWorkerDeploymentName()
 
 	// The name of the Worker Deployment in Temporal Server, prefixed by the Kubernetes namespace of the resource
-	twdName := computeWorkerDeploymentName(wrt.Namespace, wdName)
+	serverWDName := computeWorkerDeploymentName(wrt.Namespace, wdName)
 
 	selectorLabels := ComputeSelectorLabels(wdName, buildID)
 
@@ -99,7 +99,7 @@ func RenderWorkerResourceTemplate(
 	// Ordering is not a concern: matchLabels is a map; encoding/json serialises map keys in
 	// sorted order, so ComputeRenderedObjectHash is deterministic regardless of insertion order.
 	metricSelectorLabels := map[string]string{
-		"temporal_worker_deployment_name": cleanDeploymentNameForK8sLabelValue(twdName),
+		"temporal_worker_deployment_name": cleanDeploymentNameForK8sLabelValue(serverWDName),
 		"temporal_worker_build_id":        buildID,
 		"temporal_namespace":              temporalNamespace,
 	}
@@ -109,7 +109,7 @@ func RenderWorkerResourceTemplate(
 	// mutations are reflected in obj.Object directly.
 	if specRaw, ok, _ := unstructured.NestedFieldNoCopy(obj.Object, "spec"); ok {
 		if spec, ok := specRaw.(map[string]interface{}); ok {
-			autoInjectFields(spec, deployment.Name, twdName, buildID, temporalNamespace, selectorLabels, metricSelectorLabels)
+			autoInjectFields(spec, deployment.Name, serverWDName, buildID, temporalNamespace, selectorLabels, metricSelectorLabels)
 		}
 	}
 
@@ -163,12 +163,12 @@ func RenderWorkerResourceTemplate(
 //     the key is present with the empty-string opt-in sentinel. The webhook rejects
 //     non-empty values for these keys. Required by KEDA's Temporal scaler
 //     (kedacore/keda#7672) for per-version backlog scaling against Worker Deployment
-//     Versioning. twdName must be the fully-qualified Temporal-server name
+//     Versioning. serverWDName must be the fully-qualified Temporal-server name
 //     (namespace/wdName, as returned by ComputeWorkerDeploymentName).
 //
 //   - scaleTargetRef: injected anywhere in the spec tree when {} (empty), via
 //     injectScaleTargetRefRecursive. Unambiguous across all supported resource types.
-func autoInjectFields(spec map[string]interface{}, deploymentName, twdName, buildID, temporalNamespace string, podSelectorLabels map[string]string, metricSelectorLabels map[string]string) {
+func autoInjectFields(spec map[string]interface{}, deploymentName, serverWDName, buildID, temporalNamespace string, podSelectorLabels map[string]string, metricSelectorLabels map[string]string) {
 	// spec.selector.matchLabels: {} opt-in sentinel.
 	if sel, ok := spec["selector"].(map[string]interface{}); ok {
 		if isEmptyMap(sel["matchLabels"]) {
@@ -182,7 +182,7 @@ func autoInjectFields(spec map[string]interface{}, deploymentName, twdName, buil
 	}
 
 	// triggers[*].metadata: inject KEDA Temporal scaler version identifiers when present.
-	appendTemporalTriggerMetadata(spec, twdName, buildID, temporalNamespace)
+	appendKEDATriggerMetadata(spec, serverWDName, buildID, temporalNamespace)
 
 	// scaleTargetRef: inject anywhere in the spec tree.
 	injectScaleTargetRefRecursive(spec, deploymentName)
@@ -225,7 +225,7 @@ func appendMetricsMatchLabelSelector(spec map[string]interface{}, metricSelector
 	}
 }
 
-// appendTemporalTriggerMetadata walks spec.triggers[*] and, for any KEDA trigger
+// appendKEDATriggerMetadata walks spec.triggers[*] and, for any KEDA trigger
 // of type "temporal", sets workerDeploymentName, workerDeploymentBuildId, and namespace
 // in its metadata map. Injection is opt-in via the empty-string sentinel, mirroring
 // the scaleTargetRef {} sentinel pattern: absent = no injection; present-and-empty
@@ -233,7 +233,7 @@ func appendMetricsMatchLabelSelector(spec map[string]interface{}, metricSelector
 // webhook (defense in depth — if a non-empty value reaches the runtime, it is left
 // untouched rather than silently overwritten).
 //
-// twdName must be the fully-qualified Temporal-server Worker Deployment name
+// serverWDName must be the fully-qualified Temporal-server Worker Deployment name
 // (computeWorkerDeploymentName(k8sNamespace, wdName)) — that's what workers register
 // with at Temporal Cloud and what KEDA's scaler needs to query backlog for a specific
 // version. temporalNamespace is the Temporal Cloud namespace from the connection.
@@ -241,7 +241,7 @@ func appendMetricsMatchLabelSelector(spec map[string]interface{}, metricSelector
 // Required by KEDA's Temporal scaler (kedacore/keda#7672) for per-version backlog
 // scaling against Temporal's Worker Deployment Versioning model. Non-temporal
 // triggers in the same ScaledObject are untouched.
-func appendTemporalTriggerMetadata(spec map[string]interface{}, twdName, buildID, temporalNamespace string) {
+func appendKEDATriggerMetadata(spec map[string]interface{}, serverWDName, buildID, temporalNamespace string) {
 	triggers, ok := spec["triggers"].([]interface{})
 	if !ok {
 		return
@@ -260,7 +260,7 @@ func appendTemporalTriggerMetadata(spec map[string]interface{}, twdName, buildID
 			continue
 		}
 		if isEmptyString(metadata["workerDeploymentName"]) {
-			metadata["workerDeploymentName"] = twdName
+			metadata["workerDeploymentName"] = serverWDName
 		}
 		if isEmptyString(metadata["workerDeploymentBuildId"]) {
 			metadata["workerDeploymentBuildId"] = buildID

--- a/internal/k8s/workerresourcetemplates.go
+++ b/internal/k8s/workerresourcetemplates.go
@@ -109,7 +109,7 @@ func RenderWorkerResourceTemplate(
 	// mutations are reflected in obj.Object directly.
 	if specRaw, ok, _ := unstructured.NestedFieldNoCopy(obj.Object, "spec"); ok {
 		if spec, ok := specRaw.(map[string]interface{}); ok {
-			autoInjectFields(spec, deployment.Name, twdName, buildID, selectorLabels, metricSelectorLabels)
+			autoInjectFields(spec, deployment.Name, twdName, buildID, temporalNamespace, selectorLabels, metricSelectorLabels)
 		}
 	}
 
@@ -159,14 +159,16 @@ func RenderWorkerResourceTemplate(
 //     If matchLabels is absent, no injection occurs for that metric entry.
 //
 //   - spec.triggers[*].metadata (KEDA ScaledObject): for triggers of type "temporal",
-//     workerDeploymentName and workerDeploymentBuildId are set whenever the key is
-//     present in metadata (including empty string). Required by KEDA's Temporal scaler
+//     workerDeploymentName, workerDeploymentBuildId, and namespace are set whenever
+//     the key is present with the empty-string opt-in sentinel. The webhook rejects
+//     non-empty values for these keys. Required by KEDA's Temporal scaler
 //     (kedacore/keda#7672) for per-version backlog scaling against Worker Deployment
-//     Versioning.
+//     Versioning. twdName must be the fully-qualified Temporal-server name
+//     (namespace/wdName, as returned by ComputeWorkerDeploymentName).
 //
 //   - scaleTargetRef: injected anywhere in the spec tree when {} (empty), via
 //     injectScaleTargetRefRecursive. Unambiguous across all supported resource types.
-func autoInjectFields(spec map[string]interface{}, deploymentName, twdName, buildID string, podSelectorLabels map[string]string, metricSelectorLabels map[string]string) {
+func autoInjectFields(spec map[string]interface{}, deploymentName, twdName, buildID, temporalNamespace string, podSelectorLabels map[string]string, metricSelectorLabels map[string]string) {
 	// spec.selector.matchLabels: {} opt-in sentinel.
 	if sel, ok := spec["selector"].(map[string]interface{}); ok {
 		if isEmptyMap(sel["matchLabels"]) {
@@ -180,7 +182,7 @@ func autoInjectFields(spec map[string]interface{}, deploymentName, twdName, buil
 	}
 
 	// triggers[*].metadata: inject KEDA Temporal scaler version identifiers when present.
-	appendTemporalTriggerMetadata(spec, twdName, buildID)
+	appendTemporalTriggerMetadata(spec, twdName, buildID, temporalNamespace)
 
 	// scaleTargetRef: inject anywhere in the spec tree.
 	injectScaleTargetRefRecursive(spec, deploymentName)
@@ -224,22 +226,22 @@ func appendMetricsMatchLabelSelector(spec map[string]interface{}, metricSelector
 }
 
 // appendTemporalTriggerMetadata walks spec.triggers[*] and, for any KEDA trigger
-// of type "temporal", sets workerDeploymentName and workerDeploymentBuildId in its
-// metadata map. Injection is opt-in via the empty-string sentinel, mirroring the
-// scaleTargetRef {} sentinel pattern: absent = no injection; present-and-empty = inject;
-// present-and-non-empty is rejected by the WorkerResourceTemplate validating webhook
-// (defense in depth — if a non-empty value reaches the runtime, it is left untouched
-// rather than silently overwritten).
+// of type "temporal", sets workerDeploymentName, workerDeploymentBuildId, and namespace
+// in its metadata map. Injection is opt-in via the empty-string sentinel, mirroring
+// the scaleTargetRef {} sentinel pattern: absent = no injection; present-and-empty
+// = inject; present-and-non-empty is rejected by the WorkerResourceTemplate validating
+// webhook (defense in depth — if a non-empty value reaches the runtime, it is left
+// untouched rather than silently overwritten).
 //
 // twdName must be the fully-qualified Temporal-server Worker Deployment name
 // (computeWorkerDeploymentName(k8sNamespace, wdName)) — that's what workers register
 // with at Temporal Cloud and what KEDA's scaler needs to query backlog for a specific
-// version.
+// version. temporalNamespace is the Temporal Cloud namespace from the connection.
 //
 // Required by KEDA's Temporal scaler (kedacore/keda#7672) for per-version backlog
 // scaling against Temporal's Worker Deployment Versioning model. Non-temporal
 // triggers in the same ScaledObject are untouched.
-func appendTemporalTriggerMetadata(spec map[string]interface{}, twdName, buildID string) {
+func appendTemporalTriggerMetadata(spec map[string]interface{}, twdName, buildID, temporalNamespace string) {
 	triggers, ok := spec["triggers"].([]interface{})
 	if !ok {
 		return
@@ -262,6 +264,9 @@ func appendTemporalTriggerMetadata(spec map[string]interface{}, twdName, buildID
 		}
 		if isEmptyString(metadata["workerDeploymentBuildId"]) {
 			metadata["workerDeploymentBuildId"] = buildID
+		}
+		if isEmptyString(metadata["namespace"]) {
+			metadata["namespace"] = temporalNamespace
 		}
 	}
 }

--- a/internal/k8s/workerresourcetemplates_test.go
+++ b/internal/k8s/workerresourcetemplates_test.go
@@ -90,7 +90,7 @@ func TestAutoInjectFields_ScaleTargetRef(t *testing.T) {
 			"minReplicas": 1,
 			"maxReplicas": 5,
 		}
-		autoInjectFields(spec, "my-worker-abc123", "my-worker", "abc123", selectorLabels, nil)
+		autoInjectFields(spec, "my-worker-abc123", "my-worker", "abc123", "my-temporal-ns", selectorLabels, nil)
 		_, hasKey := spec["scaleTargetRef"]
 		assert.False(t, hasKey, "scaleTargetRef should not be injected when absent (user must opt in with {})")
 	})
@@ -99,7 +99,7 @@ func TestAutoInjectFields_ScaleTargetRef(t *testing.T) {
 		spec := map[string]interface{}{
 			"scaleTargetRef": map[string]interface{}{},
 		}
-		autoInjectFields(spec, "my-worker-abc123", "my-worker", "abc123", selectorLabels, nil)
+		autoInjectFields(spec, "my-worker-abc123", "my-worker", "abc123", "my-temporal-ns", selectorLabels, nil)
 		ref, ok := spec["scaleTargetRef"].(map[string]interface{})
 		require.True(t, ok)
 		assert.Equal(t, "my-worker-abc123", ref["name"])
@@ -114,7 +114,7 @@ func TestAutoInjectFields_ScaleTargetRef(t *testing.T) {
 				"kind": "Deployment",
 			},
 		}
-		autoInjectFields(spec, "my-worker-abc123", "my-worker", "abc123", selectorLabels, nil)
+		autoInjectFields(spec, "my-worker-abc123", "my-worker", "abc123", "my-temporal-ns", selectorLabels, nil)
 		ref := spec["scaleTargetRef"].(map[string]interface{})
 		assert.Equal(t, "custom-deployment", ref["name"], "should not overwrite user-provided ref")
 	})
@@ -130,7 +130,7 @@ func TestAutoInjectFields_MatchLabels(t *testing.T) {
 		spec := map[string]interface{}{
 			"selector": map[string]interface{}{},
 		}
-		autoInjectFields(spec, "my-worker-abc123", "my-worker", "abc123", selectorLabels, nil)
+		autoInjectFields(spec, "my-worker-abc123", "my-worker", "abc123", "my-temporal-ns", selectorLabels, nil)
 		selector := spec["selector"].(map[string]interface{})
 		_, hasKey := selector["matchLabels"]
 		assert.False(t, hasKey, "matchLabels should not be injected when absent (user must opt in with {})")
@@ -142,7 +142,7 @@ func TestAutoInjectFields_MatchLabels(t *testing.T) {
 				"matchLabels": map[string]interface{}{},
 			},
 		}
-		autoInjectFields(spec, "my-worker-abc123", "my-worker", "abc123", selectorLabels, nil)
+		autoInjectFields(spec, "my-worker-abc123", "my-worker", "abc123", "my-temporal-ns", selectorLabels, nil)
 		selector := spec["selector"].(map[string]interface{})
 		labels, ok := selector["matchLabels"].(map[string]interface{})
 		require.True(t, ok)
@@ -158,7 +158,7 @@ func TestAutoInjectFields_MatchLabels(t *testing.T) {
 				},
 			},
 		}
-		autoInjectFields(spec, "my-worker-abc123", "my-worker", "abc123", selectorLabels, nil)
+		autoInjectFields(spec, "my-worker-abc123", "my-worker", "abc123", "my-temporal-ns", selectorLabels, nil)
 		selector := spec["selector"].(map[string]interface{})
 		labels := selector["matchLabels"].(map[string]interface{})
 		assert.Equal(t, "label", labels["custom"], "should not overwrite user-provided labels")
@@ -189,7 +189,7 @@ func TestAutoInjectFields_MatchLabels(t *testing.T) {
 				},
 			},
 		}
-		autoInjectFields(spec, "my-worker-abc123", "my-worker", "abc123", selectorLabels, metricLabels)
+		autoInjectFields(spec, "my-worker-abc123", "my-worker", "abc123", "my-temporal-ns", selectorLabels, metricLabels)
 
 		// spec.selector.matchLabels gets pod selector labels only
 		topSelector := spec["selector"].(map[string]interface{})
@@ -236,7 +236,7 @@ func TestAutoInjectFields_MetricSelector(t *testing.T) {
 
 	t.Run("injects temporal labels when matchLabels is empty ({})", func(t *testing.T) {
 		spec := metricSpec(map[string]interface{}{})
-		autoInjectFields(spec, "my-worker-abc123", "my-worker", "abc123", podLabels, metricLabels)
+		autoInjectFields(spec, "my-worker-abc123", "my-worker", "abc123", "my-temporal-ns", podLabels, metricLabels)
 		ml := spec["metrics"].([]interface{})[0].(map[string]interface{})["external"].(map[string]interface{})["metric"].(map[string]interface{})["selector"].(map[string]interface{})["matchLabels"].(map[string]interface{})
 		assert.Equal(t, "default_my-worker", ml["temporal_worker_deployment_name"])
 		assert.Equal(t, "abc123", ml["temporal_worker_build_id"])
@@ -245,7 +245,7 @@ func TestAutoInjectFields_MetricSelector(t *testing.T) {
 
 	t.Run("merges temporal labels alongside user labels", func(t *testing.T) {
 		spec := metricSpec(map[string]interface{}{"task_type": "Activity"})
-		autoInjectFields(spec, "my-worker-abc123", "my-worker", "abc123", podLabels, metricLabels)
+		autoInjectFields(spec, "my-worker-abc123", "my-worker", "abc123", "my-temporal-ns", podLabels, metricLabels)
 		ml := spec["metrics"].([]interface{})[0].(map[string]interface{})["external"].(map[string]interface{})["metric"].(map[string]interface{})["selector"].(map[string]interface{})["matchLabels"].(map[string]interface{})
 		assert.Equal(t, "Activity", ml["task_type"], "user label must be preserved")
 		assert.Equal(t, "default_my-worker", ml["temporal_worker_deployment_name"])
@@ -266,7 +266,7 @@ func TestAutoInjectFields_MetricSelector(t *testing.T) {
 				},
 			},
 		}
-		autoInjectFields(spec, "my-worker-abc123", "my-worker", "abc123", podLabels, metricLabels)
+		autoInjectFields(spec, "my-worker-abc123", "my-worker", "abc123", "my-temporal-ns", podLabels, metricLabels)
 		sel := spec["metrics"].([]interface{})[0].(map[string]interface{})["external"].(map[string]interface{})["metric"].(map[string]interface{})["selector"].(map[string]interface{})
 		_, hasMatchLabels := sel["matchLabels"]
 		assert.False(t, hasMatchLabels, "matchLabels must not be created when absent")
@@ -274,7 +274,7 @@ func TestAutoInjectFields_MetricSelector(t *testing.T) {
 
 	t.Run("no-op when metricSelectorLabels is nil", func(t *testing.T) {
 		spec := metricSpec(map[string]interface{}{})
-		autoInjectFields(spec, "my-worker-abc123", "my-worker", "abc123", podLabels, nil)
+		autoInjectFields(spec, "my-worker-abc123", "my-worker", "abc123", "my-temporal-ns", podLabels, nil)
 		ml := spec["metrics"].([]interface{})[0].(map[string]interface{})["external"].(map[string]interface{})["metric"].(map[string]interface{})["selector"].(map[string]interface{})["matchLabels"].(map[string]interface{})
 		assert.Empty(t, ml, "no metric labels should be injected when metricSelectorLabels is nil")
 	})
@@ -298,21 +298,36 @@ func TestAutoInjectFields_TemporalTriggerMetadata(t *testing.T) {
 	const twdName = "my-worker"
 	const buildID = "abc123"
 
-	t.Run("injects workerDeploymentName and workerDeploymentBuildId when keys are present (empty string)", func(t *testing.T) {
+	t.Run("injects workerDeploymentName, workerDeploymentBuildId, namespace when keys are present (empty string)", func(t *testing.T) {
 		spec := scaledObjectSpec(map[string]interface{}{
 			"endpoint":                "us-east-1.aws.api.temporal.io:7233",
-			"namespace":               "default",
+			"namespace":               "", // opt-in sentinel
 			"taskQueue":               "my-tq",
 			"workerDeploymentName":    "",
 			"workerDeploymentBuildId": "",
 		})
-		autoInjectFields(spec, "my-worker-abc123", twdName, buildID, nil, nil)
+		autoInjectFields(spec, "my-worker-abc123", twdName, buildID, "my-temporal-ns", nil, nil)
 		md := spec["triggers"].([]interface{})[0].(map[string]interface{})["metadata"].(map[string]interface{})
 		assert.Equal(t, twdName, md["workerDeploymentName"])
 		assert.Equal(t, buildID, md["workerDeploymentBuildId"])
+		assert.Equal(t, "my-temporal-ns", md["namespace"], "namespace must be auto-injected from the Temporal connection")
+		// User-set fields are preserved.
 		assert.Equal(t, "us-east-1.aws.api.temporal.io:7233", md["endpoint"])
-		assert.Equal(t, "default", md["namespace"])
 		assert.Equal(t, "my-tq", md["taskQueue"])
+	})
+
+	t.Run("does not inject namespace when key is absent", func(t *testing.T) {
+		spec := scaledObjectSpec(map[string]interface{}{
+			"endpoint":                "us-east-1.aws.api.temporal.io:7233",
+			"taskQueue":               "my-tq",
+			"workerDeploymentName":    "",
+			"workerDeploymentBuildId": "",
+			// no namespace key at all
+		})
+		autoInjectFields(spec, "my-worker-abc123", twdName, buildID, "my-temporal-ns", nil, nil)
+		md := spec["triggers"].([]interface{})[0].(map[string]interface{})["metadata"].(map[string]interface{})
+		_, hasNamespace := md["namespace"]
+		assert.False(t, hasNamespace, "namespace must not be added when absent (opt-in)")
 	})
 
 	t.Run("does not overwrite non-empty user values (webhook rejects, runtime is defensive)", func(t *testing.T) {
@@ -325,7 +340,7 @@ func TestAutoInjectFields_TemporalTriggerMetadata(t *testing.T) {
 			"workerDeploymentName":    "user-set-name",
 			"workerDeploymentBuildId": "user-set-build",
 		})
-		autoInjectFields(spec, "my-worker-abc123", twdName, buildID, nil, nil)
+		autoInjectFields(spec, "my-worker-abc123", twdName, buildID, "my-temporal-ns", nil, nil)
 		md := spec["triggers"].([]interface{})[0].(map[string]interface{})["metadata"].(map[string]interface{})
 		assert.Equal(t, "user-set-name", md["workerDeploymentName"], "runtime must not silently overwrite non-empty user value")
 		assert.Equal(t, "user-set-build", md["workerDeploymentBuildId"], "runtime must not silently overwrite non-empty user value")
@@ -337,7 +352,7 @@ func TestAutoInjectFields_TemporalTriggerMetadata(t *testing.T) {
 			"namespace": "default",
 			"taskQueue": "my-tq",
 		})
-		autoInjectFields(spec, "my-worker-abc123", twdName, buildID, nil, nil)
+		autoInjectFields(spec, "my-worker-abc123", twdName, buildID, "my-temporal-ns", nil, nil)
 		md := spec["triggers"].([]interface{})[0].(map[string]interface{})["metadata"].(map[string]interface{})
 		_, hasName := md["workerDeploymentName"]
 		_, hasBuild := md["workerDeploymentBuildId"]
@@ -365,7 +380,7 @@ func TestAutoInjectFields_TemporalTriggerMetadata(t *testing.T) {
 				},
 			},
 		}
-		autoInjectFields(spec, "my-worker-abc123", twdName, buildID, nil, nil)
+		autoInjectFields(spec, "my-worker-abc123", twdName, buildID, "my-temporal-ns", nil, nil)
 		triggers := spec["triggers"].([]interface{})
 		promMd := triggers[0].(map[string]interface{})["metadata"].(map[string]interface{})
 		assert.Equal(t, "should-stay-untouched", promMd["workerDeploymentName"], "prometheus trigger must not be modified")
@@ -380,7 +395,7 @@ func TestAutoInjectFields_TemporalTriggerMetadata(t *testing.T) {
 			"workerDeploymentName":    "",
 			"workerDeploymentBuildId": "",
 		})
-		autoInjectFields(spec, "my-worker-abc123", twdName, buildID, nil, nil)
+		autoInjectFields(spec, "my-worker-abc123", twdName, buildID, "my-temporal-ns", nil, nil)
 		ref := spec["scaleTargetRef"].(map[string]interface{})
 		assert.Equal(t, "my-worker-abc123", ref["name"])
 		assert.Equal(t, "Deployment", ref["kind"])
@@ -390,7 +405,7 @@ func TestAutoInjectFields_TemporalTriggerMetadata(t *testing.T) {
 		spec := map[string]interface{}{
 			"minReplicas": 1,
 		}
-		autoInjectFields(spec, "my-worker-abc123", twdName, buildID, nil, nil)
+		autoInjectFields(spec, "my-worker-abc123", twdName, buildID, "my-temporal-ns", nil, nil)
 		_, hasTriggers := spec["triggers"]
 		assert.False(t, hasTriggers)
 	})

--- a/internal/k8s/workerresourcetemplates_test.go
+++ b/internal/k8s/workerresourcetemplates_test.go
@@ -9,12 +9,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	temporaliov1alpha1 "github.com/temporalio/temporal-worker-controller/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-
-	temporaliov1alpha1 "github.com/temporalio/temporal-worker-controller/api/v1alpha1"
 )
 
 // expectedWorkerResourceTemplateName replicates the naming logic for use in tests.

--- a/internal/k8s/workerresourcetemplates_test.go
+++ b/internal/k8s/workerresourcetemplates_test.go
@@ -315,15 +315,20 @@ func TestAutoInjectFields_TemporalTriggerMetadata(t *testing.T) {
 		assert.Equal(t, "my-tq", md["taskQueue"])
 	})
 
-	t.Run("overwrites pre-existing values when keys are present", func(t *testing.T) {
+	t.Run("does not overwrite non-empty user values (webhook rejects, runtime is defensive)", func(t *testing.T) {
+		// The validating webhook is the primary line of defence: a WorkerResourceTemplate
+		// whose template contains a non-empty workerDeploymentName or workerDeploymentBuildId
+		// is rejected at admission. The runtime injection is defensive: if a non-empty value
+		// somehow reaches it, the user-provided value is preserved (consistent with the
+		// scaleTargetRef pattern where only {} opts in).
 		spec := scaledObjectSpec(map[string]interface{}{
-			"workerDeploymentName":    "stale-name",
-			"workerDeploymentBuildId": "stale-build",
+			"workerDeploymentName":    "user-set-name",
+			"workerDeploymentBuildId": "user-set-build",
 		})
 		autoInjectFields(spec, "my-worker-abc123", twdName, buildID, nil, nil)
 		md := spec["triggers"].([]interface{})[0].(map[string]interface{})["metadata"].(map[string]interface{})
-		assert.Equal(t, twdName, md["workerDeploymentName"], "should overwrite stale value with current twdName")
-		assert.Equal(t, buildID, md["workerDeploymentBuildId"], "should overwrite stale value with current buildID")
+		assert.Equal(t, "user-set-name", md["workerDeploymentName"], "runtime must not silently overwrite non-empty user value")
+		assert.Equal(t, "user-set-build", md["workerDeploymentBuildId"], "runtime must not silently overwrite non-empty user value")
 	})
 
 	t.Run("does not inject when keys are absent", func(t *testing.T) {

--- a/internal/k8s/workerresourcetemplates_test.go
+++ b/internal/k8s/workerresourcetemplates_test.go
@@ -90,7 +90,7 @@ func TestAutoInjectFields_ScaleTargetRef(t *testing.T) {
 			"minReplicas": 1,
 			"maxReplicas": 5,
 		}
-		autoInjectFields(spec, "my-worker-abc123", selectorLabels, nil)
+		autoInjectFields(spec, "my-worker-abc123", "my-worker", "abc123", selectorLabels, nil)
 		_, hasKey := spec["scaleTargetRef"]
 		assert.False(t, hasKey, "scaleTargetRef should not be injected when absent (user must opt in with {})")
 	})
@@ -99,7 +99,7 @@ func TestAutoInjectFields_ScaleTargetRef(t *testing.T) {
 		spec := map[string]interface{}{
 			"scaleTargetRef": map[string]interface{}{},
 		}
-		autoInjectFields(spec, "my-worker-abc123", selectorLabels, nil)
+		autoInjectFields(spec, "my-worker-abc123", "my-worker", "abc123", selectorLabels, nil)
 		ref, ok := spec["scaleTargetRef"].(map[string]interface{})
 		require.True(t, ok)
 		assert.Equal(t, "my-worker-abc123", ref["name"])
@@ -114,7 +114,7 @@ func TestAutoInjectFields_ScaleTargetRef(t *testing.T) {
 				"kind": "Deployment",
 			},
 		}
-		autoInjectFields(spec, "my-worker-abc123", selectorLabels, nil)
+		autoInjectFields(spec, "my-worker-abc123", "my-worker", "abc123", selectorLabels, nil)
 		ref := spec["scaleTargetRef"].(map[string]interface{})
 		assert.Equal(t, "custom-deployment", ref["name"], "should not overwrite user-provided ref")
 	})
@@ -130,7 +130,7 @@ func TestAutoInjectFields_MatchLabels(t *testing.T) {
 		spec := map[string]interface{}{
 			"selector": map[string]interface{}{},
 		}
-		autoInjectFields(spec, "my-worker-abc123", selectorLabels, nil)
+		autoInjectFields(spec, "my-worker-abc123", "my-worker", "abc123", selectorLabels, nil)
 		selector := spec["selector"].(map[string]interface{})
 		_, hasKey := selector["matchLabels"]
 		assert.False(t, hasKey, "matchLabels should not be injected when absent (user must opt in with {})")
@@ -142,7 +142,7 @@ func TestAutoInjectFields_MatchLabels(t *testing.T) {
 				"matchLabels": map[string]interface{}{},
 			},
 		}
-		autoInjectFields(spec, "my-worker-abc123", selectorLabels, nil)
+		autoInjectFields(spec, "my-worker-abc123", "my-worker", "abc123", selectorLabels, nil)
 		selector := spec["selector"].(map[string]interface{})
 		labels, ok := selector["matchLabels"].(map[string]interface{})
 		require.True(t, ok)
@@ -158,7 +158,7 @@ func TestAutoInjectFields_MatchLabels(t *testing.T) {
 				},
 			},
 		}
-		autoInjectFields(spec, "my-worker-abc123", selectorLabels, nil)
+		autoInjectFields(spec, "my-worker-abc123", "my-worker", "abc123", selectorLabels, nil)
 		selector := spec["selector"].(map[string]interface{})
 		labels := selector["matchLabels"].(map[string]interface{})
 		assert.Equal(t, "label", labels["custom"], "should not overwrite user-provided labels")
@@ -189,7 +189,7 @@ func TestAutoInjectFields_MatchLabels(t *testing.T) {
 				},
 			},
 		}
-		autoInjectFields(spec, "my-worker-abc123", selectorLabels, metricLabels)
+		autoInjectFields(spec, "my-worker-abc123", "my-worker", "abc123", selectorLabels, metricLabels)
 
 		// spec.selector.matchLabels gets pod selector labels only
 		topSelector := spec["selector"].(map[string]interface{})
@@ -236,7 +236,7 @@ func TestAutoInjectFields_MetricSelector(t *testing.T) {
 
 	t.Run("injects temporal labels when matchLabels is empty ({})", func(t *testing.T) {
 		spec := metricSpec(map[string]interface{}{})
-		autoInjectFields(spec, "my-worker-abc123", podLabels, metricLabels)
+		autoInjectFields(spec, "my-worker-abc123", "my-worker", "abc123", podLabels, metricLabels)
 		ml := spec["metrics"].([]interface{})[0].(map[string]interface{})["external"].(map[string]interface{})["metric"].(map[string]interface{})["selector"].(map[string]interface{})["matchLabels"].(map[string]interface{})
 		assert.Equal(t, "default_my-worker", ml["temporal_worker_deployment_name"])
 		assert.Equal(t, "abc123", ml["temporal_worker_build_id"])
@@ -245,7 +245,7 @@ func TestAutoInjectFields_MetricSelector(t *testing.T) {
 
 	t.Run("merges temporal labels alongside user labels", func(t *testing.T) {
 		spec := metricSpec(map[string]interface{}{"task_type": "Activity"})
-		autoInjectFields(spec, "my-worker-abc123", podLabels, metricLabels)
+		autoInjectFields(spec, "my-worker-abc123", "my-worker", "abc123", podLabels, metricLabels)
 		ml := spec["metrics"].([]interface{})[0].(map[string]interface{})["external"].(map[string]interface{})["metric"].(map[string]interface{})["selector"].(map[string]interface{})["matchLabels"].(map[string]interface{})
 		assert.Equal(t, "Activity", ml["task_type"], "user label must be preserved")
 		assert.Equal(t, "default_my-worker", ml["temporal_worker_deployment_name"])
@@ -266,7 +266,7 @@ func TestAutoInjectFields_MetricSelector(t *testing.T) {
 				},
 			},
 		}
-		autoInjectFields(spec, "my-worker-abc123", podLabels, metricLabels)
+		autoInjectFields(spec, "my-worker-abc123", "my-worker", "abc123", podLabels, metricLabels)
 		sel := spec["metrics"].([]interface{})[0].(map[string]interface{})["external"].(map[string]interface{})["metric"].(map[string]interface{})["selector"].(map[string]interface{})
 		_, hasMatchLabels := sel["matchLabels"]
 		assert.False(t, hasMatchLabels, "matchLabels must not be created when absent")
@@ -274,9 +274,120 @@ func TestAutoInjectFields_MetricSelector(t *testing.T) {
 
 	t.Run("no-op when metricSelectorLabels is nil", func(t *testing.T) {
 		spec := metricSpec(map[string]interface{}{})
-		autoInjectFields(spec, "my-worker-abc123", podLabels, nil)
+		autoInjectFields(spec, "my-worker-abc123", "my-worker", "abc123", podLabels, nil)
 		ml := spec["metrics"].([]interface{})[0].(map[string]interface{})["external"].(map[string]interface{})["metric"].(map[string]interface{})["selector"].(map[string]interface{})["matchLabels"].(map[string]interface{})
 		assert.Empty(t, ml, "no metric labels should be injected when metricSelectorLabels is nil")
+	})
+}
+
+// scaledObjectSpec builds a minimal KEDA ScaledObject spec with one temporal trigger
+// whose metadata starts with the given base entries.
+func scaledObjectSpec(temporalMetadata map[string]interface{}) map[string]interface{} {
+	return map[string]interface{}{
+		"scaleTargetRef": map[string]interface{}{}, // opt in to auto-injection
+		"triggers": []interface{}{
+			map[string]interface{}{
+				"type":     "temporal",
+				"metadata": temporalMetadata,
+			},
+		},
+	}
+}
+
+func TestAutoInjectFields_TemporalTriggerMetadata(t *testing.T) {
+	const twdName = "my-worker"
+	const buildID = "abc123"
+
+	t.Run("injects workerDeploymentName and workerDeploymentBuildId when keys are present (empty string)", func(t *testing.T) {
+		spec := scaledObjectSpec(map[string]interface{}{
+			"endpoint":                "us-east-1.aws.api.temporal.io:7233",
+			"namespace":               "default",
+			"taskQueue":               "my-tq",
+			"workerDeploymentName":    "",
+			"workerDeploymentBuildId": "",
+		})
+		autoInjectFields(spec, "my-worker-abc123", twdName, buildID, nil, nil)
+		md := spec["triggers"].([]interface{})[0].(map[string]interface{})["metadata"].(map[string]interface{})
+		assert.Equal(t, twdName, md["workerDeploymentName"])
+		assert.Equal(t, buildID, md["workerDeploymentBuildId"])
+		assert.Equal(t, "us-east-1.aws.api.temporal.io:7233", md["endpoint"])
+		assert.Equal(t, "default", md["namespace"])
+		assert.Equal(t, "my-tq", md["taskQueue"])
+	})
+
+	t.Run("overwrites pre-existing values when keys are present", func(t *testing.T) {
+		spec := scaledObjectSpec(map[string]interface{}{
+			"workerDeploymentName":    "stale-name",
+			"workerDeploymentBuildId": "stale-build",
+		})
+		autoInjectFields(spec, "my-worker-abc123", twdName, buildID, nil, nil)
+		md := spec["triggers"].([]interface{})[0].(map[string]interface{})["metadata"].(map[string]interface{})
+		assert.Equal(t, twdName, md["workerDeploymentName"], "should overwrite stale value with current twdName")
+		assert.Equal(t, buildID, md["workerDeploymentBuildId"], "should overwrite stale value with current buildID")
+	})
+
+	t.Run("does not inject when keys are absent", func(t *testing.T) {
+		spec := scaledObjectSpec(map[string]interface{}{
+			"endpoint":  "us-east-1.aws.api.temporal.io:7233",
+			"namespace": "default",
+			"taskQueue": "my-tq",
+		})
+		autoInjectFields(spec, "my-worker-abc123", twdName, buildID, nil, nil)
+		md := spec["triggers"].([]interface{})[0].(map[string]interface{})["metadata"].(map[string]interface{})
+		_, hasName := md["workerDeploymentName"]
+		_, hasBuild := md["workerDeploymentBuildId"]
+		assert.False(t, hasName, "workerDeploymentName must not be added when absent (opt-in)")
+		assert.False(t, hasBuild, "workerDeploymentBuildId must not be added when absent (opt-in)")
+	})
+
+	t.Run("does not touch non-temporal triggers", func(t *testing.T) {
+		spec := map[string]interface{}{
+			"triggers": []interface{}{
+				map[string]interface{}{
+					"type": "prometheus",
+					"metadata": map[string]interface{}{
+						"serverAddress":           "http://prom",
+						"workerDeploymentName":    "should-stay-untouched",
+						"workerDeploymentBuildId": "should-stay-untouched",
+					},
+				},
+				map[string]interface{}{
+					"type": "temporal",
+					"metadata": map[string]interface{}{
+						"workerDeploymentName":    "",
+						"workerDeploymentBuildId": "",
+					},
+				},
+			},
+		}
+		autoInjectFields(spec, "my-worker-abc123", twdName, buildID, nil, nil)
+		triggers := spec["triggers"].([]interface{})
+		promMd := triggers[0].(map[string]interface{})["metadata"].(map[string]interface{})
+		assert.Equal(t, "should-stay-untouched", promMd["workerDeploymentName"], "prometheus trigger must not be modified")
+		assert.Equal(t, "should-stay-untouched", promMd["workerDeploymentBuildId"], "prometheus trigger must not be modified")
+		tempMd := triggers[1].(map[string]interface{})["metadata"].(map[string]interface{})
+		assert.Equal(t, twdName, tempMd["workerDeploymentName"])
+		assert.Equal(t, buildID, tempMd["workerDeploymentBuildId"])
+	})
+
+	t.Run("scaleTargetRef auto-injection still works for ScaledObject", func(t *testing.T) {
+		spec := scaledObjectSpec(map[string]interface{}{
+			"workerDeploymentName":    "",
+			"workerDeploymentBuildId": "",
+		})
+		autoInjectFields(spec, "my-worker-abc123", twdName, buildID, nil, nil)
+		ref := spec["scaleTargetRef"].(map[string]interface{})
+		assert.Equal(t, "my-worker-abc123", ref["name"])
+		assert.Equal(t, "Deployment", ref["kind"])
+	})
+
+	t.Run("no-op when triggers is absent", func(t *testing.T) {
+		spec := map[string]interface{}{
+			"minReplicas": 1,
+		}
+		autoInjectFields(spec, "my-worker-abc123", twdName, buildID, nil, nil)
+		_, hasTriggers := spec["triggers"]
+		assert.False(t, hasTriggers)
 	})
 }
 

--- a/internal/k8s/workerresourcetemplates_test.go
+++ b/internal/k8s/workerresourcetemplates_test.go
@@ -9,11 +9,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	temporaliov1alpha1 "github.com/temporalio/temporal-worker-controller/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+
+	temporaliov1alpha1 "github.com/temporalio/temporal-worker-controller/api/v1alpha1"
 )
 
 // expectedWorkerResourceTemplateName replicates the naming logic for use in tests.


### PR DESCRIPTION
## Summary

Extends `WorkerResourceTemplate` auto-injection to populate the `workerDeploymentName` and `workerDeploymentBuildId` fields in KEDA `ScaledObject` `triggers[*].metadata` when the trigger `type` is `"temporal"`. This unblocks using KEDA's Temporal scaler ([kedacore/keda#7672](https://github.com/kedacore/keda/pull/7672)) as the templated resource for per-version backlog scaling, as requested in #286.

Closes (or contributes towards) #286.

## Motivation

For users who already run KEDA cluster-wide for non-Temporal workloads, KEDA owns the `external.metrics.k8s.io` APIService — only one external metrics provider can be installed per cluster. That makes the documented WRT-HPA + prometheus-adapter path unavailable: prometheus-adapter cannot co-exist with KEDA on the same APIService.

KEDA's recent Worker Deployment Versioning support (kedacore/keda#7672) makes it possible for a KEDA `ScaledObject` to scale a single worker version by querying Temporal Cloud directly with `workerDeploymentName` + `workerDeploymentBuildId`. WRT already supports templating arbitrary kinds (verified: `spec.template` is unstructured, SSA-applied, with a kind allow-list in the chart) and `scaleTargetRef: {}` auto-fill works recursively. The only missing piece was injecting the per-version identifiers into the KEDA trigger metadata — same source values the controller already injects into HPA External metric selectors, different JSON path.

## Behaviour

For each templated resource that contains:

```yaml
spec:
  triggers:
    - type: temporal
      metadata:
        workerDeploymentName: ""        # placeholder, any string value
        workerDeploymentBuildId: ""     # placeholder, any string value
        # ...other user-provided KEDA Temporal scaler metadata
```

the controller sets:

- `workerDeploymentName` ← `wrt.Spec.EffectiveWorkerDeploymentName()`
- `workerDeploymentBuildId` ← the per-version build ID

Injection is **opt-in**: the keys are only touched if already present in the template's `metadata` map (mirroring the existing `metrics[*].external.metric.selector.matchLabels` merge pattern). Non-`temporal` triggers in the same `ScaledObject` are left untouched.

## Example

```yaml
apiVersion: temporal.io/v1alpha1
kind: WorkerResourceTemplate
metadata:
  name: my-worker-scaler
  namespace: default
spec:
  workerDeploymentRef:
    name: my-worker
  template:
    apiVersion: keda.sh/v1alpha1
    kind: ScaledObject
    spec:
      scaleTargetRef: {}                     # auto-injected (versioned Deployment)
      minReplicaCount: 1
      maxReplicaCount: 10
      pollingInterval: 30
      triggers:
        - type: temporal
          metadata:
            endpoint: us-east-1.aws.api.temporal.io:7233
            namespace: my-temporal-ns
            taskQueue: my-task-queue
            workerDeploymentName: ""         # auto-injected
            workerDeploymentBuildId: ""      # auto-injected
            targetQueueSize: "10"
          authenticationRef:
            kind: ClusterTriggerAuthentication
            name: temporal-cloud-auth
```

The controller will stamp one `ScaledObject` per active worker version, each with the correct `workerDeploymentBuildId`, and delete them on sunset via the existing `DeleteWorkerResources` planner (kind-agnostic).

## Implementation

- `appendTemporalTriggerMetadata(spec, twdName, buildID)` — new helper that walks `spec.triggers[*]`, filters on `type == "temporal"`, and sets the two keys if already present.
- `autoInjectFields` signature now takes `twdName, buildID` so it can pass them through. Behaviour for HPA / matchLabels / scaleTargetRef is unchanged.

Helm-side: adding `ScaledObject` to `workerResourceTemplate.allowedResources` + the controller's `ClusterRole` is left as a follow-up (or a separate commit in this PR if maintainers prefer). For users who want this today, they can add the entry to their chart values without further controller changes.

## Tests

New `TestAutoInjectFields_TemporalTriggerMetadata` covers:

- injects when both keys present (empty string placeholders)
- overwrites stale values
- no-op when keys absent (opt-in semantics)
- non-`temporal` triggers are untouched (heterogeneous trigger array)
- `scaleTargetRef: {}` auto-fill still works on `ScaledObject`
- no panic when `spec.triggers` is absent

All existing tests still pass (`go test ./...`).
