### PR TITLE
chore(deps): consolidate go mod tidying + one Dependabot PR per dependency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,25 +1,23 @@
 version: 2
 updates:
+  # One entry covering all Go modules. group-by: dependency-name makes Dependabot
+  # raise one PR per dependency spanning every listed directory, rather than a
+  # separate PR per module.
   - package-ecosystem: gomod
-    directory: "/"
+    directories:
+      - "/"
+      - "/internal/demo"
+      - "/internal/tests"
     schedule:
       interval: weekly
     cooldown:
       default-days: 14
-
-  - package-ecosystem: gomod
-    directory: "/internal/demo"
-    schedule:
-      interval: weekly
-    cooldown:
-      default-days: 14
-
-  - package-ecosystem: gomod
-    directory: "/internal/tests"
-    schedule:
-      interval: weekly
-    cooldown:
-      default-days: 14
+    groups:
+      go-modules:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        group-by: dependency-name
 
   - package-ecosystem: helm
     directory: "/helm/temporal-worker-controller"

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -49,6 +49,32 @@ jobs:
             exit 1
           fi
 
+  tidy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+        with:
+          go-version-file: 'go.mod'
+          check-latest: true
+          cache: true
+
+      - name: tidy go modules
+        run: |
+          make tidy
+
+      - name: check-is-dirty
+        run: |
+          if [[ -n $(git status --porcelain) ]]; then
+            echo "Detected uncommitted changes. Run 'make tidy' and commit the result."
+            git status
+            git diff
+            exit 1
+          fi
+
   golangci:
     runs-on: ubuntu-latest
     steps:
@@ -96,6 +122,7 @@ jobs:
     needs:
       - lint-actions
       - fmt-imports
+      - tidy
       - golangci
       - go-vet
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -360,3 +360,14 @@ fmt: ## Run go fmt against code.
 .PHONY: vet
 vet: ## Run go vet against code.
 	go vet ./...
+
+##### Go modules #####
+# All Go module directories in the repo (root + submodules), discovered from go.mod files.
+GO_MODULE_DIRS := $(shell find . -name go.mod -not -path './bin/*' -exec dirname {} \;)
+
+.PHONY: tidy
+tidy: ## Run go mod tidy in every module. Run after checking out a Dependabot branch.
+	@for dir in $(GO_MODULE_DIRS); do \
+		printf $(COLOR) "Tidying go module: $$dir"; \
+		GOWORK=off go mod tidy -C $$dir || exit 1; \
+	done


### PR DESCRIPTION
## Why

Dependabot currently has three separate `gomod` update entries (one per module: `/`, `/internal/demo`, `/internal/tests`). A dependency used in more than one module produces a **separate PR per module**, so no single PR is complete on its own and they have to be stitched together by hand.

## What

- **`make tidy`** — runs `go mod tidy` in every Go module (auto-discovered from `go.mod` files) with `GOWORK=off`. It only reconciles `go.mod`/`go.sum` and never upgrades, so it's a minimal-diff finalizer to run after checking out a Dependabot branch.
- **`.github/dependabot.yml`** — collapse the three `gomod` entries into one using `directories` + `groups.group-by: dependency-name`, so each dependency produces **one PR spanning all modules**. `helm` and `github-actions` entries unchanged. ([Feb 2026 Dependabot changelog](https://github.blog/changelog/2026-02-24-dependabot-can-group-updates-by-dependency-name-across-multiple-directories/))
- **`.github/workflows/linters.yml`** — new `tidy` CI job (mirrors `fmt-imports`) that runs `make tidy` and fails if the tree is not tidy. Added to the `linters-succeed` aggregator.

## Verification

- `make tidy` on a clean tree → zero module changes (safe, minimal-diff).
- Simulated a Dependabot bump (`prometheus/client_golang` v1.23.0→v1.23.2) → diff scoped to that one dependency; demo module builds.
- Staged an untidy `go.mod` as baseline → `make tidy` + the CI dirty-check correctly fails.

## Follow-up (manual, after merge)

The cross-directory grouping can't be tested locally. After merge, trigger a run via **Insights → Dependency graph → Dependabot → "Check for updates"**, then close the currently-open fragmented gomod PRs and let the new config regenerate consolidated ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)