### PR TITLE
fix(helm): use dynamic SA name in proxy-rolebinding subject

### DIFF
--- a/helm/temporal-worker-controller/templates/auth_proxy.yaml
+++ b/helm/temporal-worker-controller/templates/auth_proxy.yaml
@@ -44,7 +44,7 @@ roleRef:
   name: {{ .Release.Name }}-{{ .Release.Namespace }}-proxy-role
 subjects:
   - kind: ServiceAccount
-    name: controller-manager
+    name: {{ .Values.serviceAccount.name | default (printf "%s-service-account" .Release.Name) }}
     namespace: {{ .Release.Namespace }}
 ---
 apiVersion: v1


### PR DESCRIPTION
## Summary

Fixes #374.

The `proxy-rolebinding` ClusterRoleBinding in `auth_proxy.yaml` hardcoded `controller-manager` as the ServiceAccount subject. Every other binding in `rbac.yaml` correctly uses the dynamic expression:

\`\`\`yaml
name: {{ .Values.serviceAccount.name | default (printf "%s-service-account" .Release.Name) }}
\`\`\`

With the default release name recommended in the README (`temporal-worker-controller`), the rendered SA name is `temporal-worker-controller-service-account`, so the `proxy-rolebinding` was pointing to a non-existent SA. This caused the `kube-rbac-proxy` sidecar to silently lack the `proxy-role` permissions, breaking authenticated metrics scraping.

## Change

One-line fix — align the `proxy-rolebinding` subject with all other bindings.

## Testing

Verified with `helm template`:
- Before: subject was `controller-manager`
- After: subject is `temporal-worker-controller-service-account` (matching the rendered SA)

Note: a proper Helm unit test for this is blocked on #364 (`make test-unit` fails due to the cert-manager chart dependency issue in the test harness).

Made with [Cursor](https://cursor.com)