### PR TITLE
Retry transient transport failures on the raw DescribeWorkerDeployment call

### DIFF
--- a/internal/temporal/worker_deployment.go
+++ b/internal/temporal/worker_deployment.go
@@ -11,6 +11,9 @@ import (
 	"strings"
 	"time"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	temporaliov1alpha1 "github.com/temporalio/temporal-worker-controller/api/v1alpha1"
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
@@ -75,10 +78,22 @@ func GetWorkerDeploymentState(
 
 	// Describe the worker deployment using gRPC API directly to get full version summary info
 	// (including drainage timestamps) without needing per-version DescribeVersion calls.
-	resp, err := client.WorkflowService().DescribeWorkerDeployment(ctx, &workflowservice.DescribeWorkerDeploymentRequest{
-		Namespace:      namespace,
-		DeploymentName: workerDeploymentName,
+	//
+	// Raw WorkflowService calls bypass the SDK's built-in retry interceptor (it only
+	// engages for the SDK's own high-level methods), so a single transient transport
+	// blip here would otherwise abort the whole reconcile pass — stacking
+	// controller-runtime backoff on top and delaying drained-version sunsets by hours.
+	// Retry transient failures briefly before giving up.
+	var resp *workflowservice.DescribeWorkerDeploymentResponse
+	describeErr := retryTransient(ctx, 3, time.Second, func() error {
+		var err error
+		resp, err = client.WorkflowService().DescribeWorkerDeployment(ctx, &workflowservice.DescribeWorkerDeploymentRequest{
+			Namespace:      namespace,
+			DeploymentName: workerDeploymentName,
+		})
+		return err
 	})
+	err := describeErr
 	if err != nil {
 		var notFound *serviceerror.NotFound
 		if errors.As(err, &notFound) {
@@ -181,6 +196,37 @@ func GetWorkerDeploymentState(
 	}
 
 	return state, nil
+}
+
+// retryTransient runs fn up to attempts times, retrying only transient
+// transport-level failures (mirroring the retryable set of the SDK's own
+// interceptor) with linear backoff. Context cancellation stops retries.
+func retryTransient(ctx context.Context, attempts int, backoff time.Duration, fn func() error) error {
+	var lastErr error
+	for i := 0; i < attempts; i++ {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		lastErr = fn()
+		if lastErr == nil || !isTransientGRPCError(lastErr) {
+			return lastErr
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(backoff * time.Duration(i+1)):
+		}
+	}
+	return lastErr
+}
+
+// isTransientGRPCError mirrors the SDK retry interceptor's retryable codes.
+func isTransientGRPCError(err error) bool {
+	switch status.Code(err) {
+	case codes.Unavailable, codes.Unknown, codes.Aborted, codes.ResourceExhausted:
+		return true
+	}
+	return false
 }
 
 func withBackoff(timeout time.Duration, tick time.Duration, fn func() error) error {

--- a/internal/temporal/worker_deployment_test.go
+++ b/internal/temporal/worker_deployment_test.go
@@ -5,8 +5,12 @@
 package temporal
 
 import (
+	"context"
 	"testing"
 	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/stretchr/testify/assert"
 	temporaliov1alpha1 "github.com/temporalio/temporal-worker-controller/api/v1alpha1"
@@ -115,4 +119,62 @@ func eventually(t *testing.T, timeout, interval time.Duration, check func() erro
 	if lastErr != nil {
 		t.Fatalf("eventually failed after %s: %v", timeout, lastErr)
 	}
+}
+
+func TestRetryTransient(t *testing.T) {
+	t.Run("retries transient errors until success", func(t *testing.T) {
+		calls := 0
+		err := retryTransient(context.Background(), 3, time.Millisecond, func() error {
+			calls++
+			if calls < 3 {
+				return status.Error(codes.Unavailable, "transport blip")
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("expected success after retries, got %v", err)
+		}
+		if calls != 3 {
+			t.Fatalf("expected 3 calls, got %d", calls)
+		}
+	})
+
+	t.Run("does not retry non-transient errors", func(t *testing.T) {
+		calls := 0
+		err := retryTransient(context.Background(), 3, time.Millisecond, func() error {
+			calls++
+			return status.Error(codes.NotFound, "missing")
+		})
+		if status.Code(err) != codes.NotFound {
+			t.Fatalf("expected NotFound, got %v", err)
+		}
+		if calls != 1 {
+			t.Fatalf("expected 1 call, got %d", calls)
+		}
+	})
+
+	t.Run("gives up after max attempts", func(t *testing.T) {
+		calls := 0
+		err := retryTransient(context.Background(), 3, time.Millisecond, func() error {
+			calls++
+			return status.Error(codes.Unavailable, "still down")
+		})
+		if status.Code(err) != codes.Unavailable {
+			t.Fatalf("expected Unavailable, got %v", err)
+		}
+		if calls != 3 {
+			t.Fatalf("expected 3 calls, got %d", calls)
+		}
+	})
+
+	t.Run("stops on context cancellation", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		err := retryTransient(ctx, 3, time.Millisecond, func() error {
+			return status.Error(codes.Unavailable, "down")
+		})
+		if err != context.Canceled {
+			t.Fatalf("expected context.Canceled, got %v", err)
+		}
+	})
 }


### PR DESCRIPTION
## Problem

`GetWorkerDeploymentState` calls `client.WorkflowService().DescribeWorkerDeployment(...)` as a raw gRPC stub call. Raw `WorkflowService()` calls bypass the Go SDK's built-in retry interceptor — it only engages when the SDK's own high-level client methods put a retry config into the call context (`internal/common/retry.ConfigKey`, not settable from outside the SDK). So this call gets **zero retries**, while every other Temporal call in the reconcile path (deployment handler methods, `DescribeTaskQueue`) is silently retried by the SDK.

Since this describe is the first Temporal RPC of every reconcile pass, a single transient transport blip (e.g. `Unavailable` after a gRPC keepalive kill: `read tcp ...:7233: read: connection timed out`) aborts the whole pass, and controller-runtime's exponential backoff stacks on top. In our production cluster (GKE → Temporal Cloud, controller v1.7.0) intermittent blips like this delayed drained-version sunsets by many hours — we observed a fully-drained version sit undeleted for 17h while reconciles repeatedly failed at this call (~20 such failures over 24h, in bursts).

## Fix

Wrap only this raw call in a small transient-aware retry (3 attempts, linear backoff, context-aware). The retryable code set mirrors the SDK interceptor's own (`Unavailable`, `Unknown`, `Aborted`, `ResourceExhausted`); semantic errors like `NotFound` still return immediately and keep the existing empty-state handling.

## Testing

- `go test ./internal/temporal/` green; added unit tests for the retry helper (retries transient → success, non-transient fails fast, attempt cap, context cancellation).