### PR TITLE
bug: ensure drained versions stable sort in status

### DIFF
--- a/internal/controller/state_mapper.go
+++ b/internal/controller/state_mapper.go
@@ -5,6 +5,9 @@
 package controller
 
 import (
+	"cmp"
+	"slices"
+
 	"github.com/temporalio/temporal-worker-controller/api/v1alpha1"
 	"github.com/temporalio/temporal-worker-controller/internal/k8s"
 	"github.com/temporalio/temporal-worker-controller/internal/temporal"
@@ -65,6 +68,17 @@ func (m *stateMapper) mapToStatus(targetBuildID string) *v1alpha1.WorkerDeployme
 			deprecatedVersions = append(deprecatedVersions, versionStatus)
 		}
 	}
+	// NOTE(jaypipes): Need to sort the deprecated versions here in order to
+	// prevent sort order differences from causing unnecessary status
+	// generation increments.
+	//
+	// See: https://github.com/temporalio/temporal-worker-controller/issues/415
+	slices.SortStableFunc(
+		deprecatedVersions,
+		func(a, b *v1alpha1.DeprecatedWorkerDeploymentVersion) int {
+			return cmp.Compare(a.BuildID, b.BuildID)
+		},
+	)
 	status.DeprecatedVersions = deprecatedVersions
 
 	// Set version count from temporal state (directly from VersionSummaries via Versions map)


### PR DESCRIPTION
The reconciler loop is "hot", meaning, it is bumping the Revision of the WorkerDeployment CRs too often. One of the reasons for this is that the WorkerDeployment.Status struct was being evaluated as different from a previous iteration of the reconciler loop for the same WorkerDeployment due to differences in the sort order of the collection of drained build IDs.

This commit adds stable sorting of these drained build IDs in the `WorkerDeploymentStatus` struct in order to eliminate this false positive detection of a difference in status.

The other cause for false-positive detection of status differences identified in issue #415 -- where rate limiting errors cause a temporary condition change -- will be addressed in a followup PR.

Issue #415