### PR TITLE
Fix/register workerdeployment webhook

### DIFF
--- a/api/v1alpha1/webhook_suite_test.go
+++ b/api/v1alpha1/webhook_suite_test.go
@@ -63,7 +63,11 @@ var _ = BeforeSuite(func() {
 	ctx, cancel = context.WithCancel(context.TODO())
 
 	By("bootstrapping test environment")
-	wrtWebhook := loadWRTWebhookFromHelmChart(filepath.Join("..", "..", "helm", "temporal-worker-controller"))
+	chartPath := filepath.Join("..", "..", "helm", "temporal-worker-controller")
+	wrtWebhook := loadWebhookFromHelmChart(chartPath, "vworkerresourcetemplate.kb.io")
+	// The WorkerDeployment webhook config is gated behind the chart's webhook.enabled flag,
+	// so render it the same way a real install with the flag on would.
+	wdWebhook := loadWebhookFromHelmChart(chartPath, "vworkerdeployment.kb.io", "--set", "webhook.enabled=true")
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths: []string{
 			// CRDs live in the crds chart's templates directory
@@ -71,7 +75,7 @@ var _ = BeforeSuite(func() {
 		},
 		ErrorIfCRDPathMissing: true,
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
-			ValidatingWebhooks: []*admissionregistrationv1.ValidatingWebhookConfiguration{wrtWebhook},
+			ValidatingWebhooks: []*admissionregistrationv1.ValidatingWebhookConfiguration{wrtWebhook, wdWebhook},
 		},
 	}
 
@@ -157,29 +161,31 @@ var _ = BeforeSuite(func() {
 
 })
 
-// loadWRTWebhookFromHelmChart renders the Helm chart's webhook.yaml with default values using
-// `helm template` and extracts the ValidatingWebhookConfiguration for WorkerResourceTemplate.
+// loadWebhookFromHelmChart renders the Helm chart's webhook.yaml using `helm template`
+// (with any extra helm arguments, e.g. --set webhook.enabled=true) and extracts the
+// ValidatingWebhookConfiguration containing the named webhook.
 // This makes the test authoritative against the Helm chart rather than a hand-maintained copy.
-func loadWRTWebhookFromHelmChart(chartPath string) *admissionregistrationv1.ValidatingWebhookConfiguration {
-	out, err := exec.Command("helm", "template", "test", chartPath, "--show-only", "templates/webhook.yaml").Output()
+func loadWebhookFromHelmChart(chartPath, webhookName string, extraArgs ...string) *admissionregistrationv1.ValidatingWebhookConfiguration {
+	args := append([]string{"template", "test", chartPath, "--show-only", "templates/webhook.yaml"}, extraArgs...)
+	out, err := exec.Command("helm", args...).Output()
 	Expect(err).NotTo(HaveOccurred(), "helm template failed — is helm installed?")
 
-	// The file contains multiple YAML documents; find the WRT ValidatingWebhookConfiguration.
+	// The file contains multiple YAML documents; find the requested ValidatingWebhookConfiguration.
 	for _, doc := range bytes.Split(out, []byte("\n---\n")) {
 		trimmed := strings.TrimSpace(string(doc))
 		if !strings.Contains(trimmed, "kind: ValidatingWebhookConfiguration") {
 			continue
 		}
-		if !strings.Contains(trimmed, "vworkerresourcetemplate.kb.io") {
+		if !strings.Contains(trimmed, webhookName) {
 			continue
 		}
 		jsonBytes, convErr := sigsyaml.YAMLToJSON([]byte(trimmed))
-		Expect(convErr).NotTo(HaveOccurred(), "failed to convert WRT webhook YAML to JSON")
+		Expect(convErr).NotTo(HaveOccurred(), "failed to convert webhook YAML to JSON")
 		var wh admissionregistrationv1.ValidatingWebhookConfiguration
-		Expect(json.Unmarshal(jsonBytes, &wh)).To(Succeed(), "failed to decode WRT ValidatingWebhookConfiguration")
+		Expect(json.Unmarshal(jsonBytes, &wh)).To(Succeed(), "failed to decode ValidatingWebhookConfiguration")
 		return &wh
 	}
-	Fail("WRT ValidatingWebhookConfiguration not found in rendered helm chart webhook.yaml")
+	Fail(fmt.Sprintf("ValidatingWebhookConfiguration containing %q not found in rendered helm chart webhook.yaml", webhookName))
 	return nil
 }
 

--- a/api/v1alpha1/workerdeployment_webhook_integration_test.go
+++ b/api/v1alpha1/workerdeployment_webhook_integration_test.go
@@ -1,0 +1,119 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2024 Datadog, Inc.
+
+package v1alpha1
+
+// Integration tests for the WorkerDeployment validating webhook.
+//
+// These tests run through the real envtest HTTP admission path — the kube-apiserver
+// sends actual AdmissionRequests to the webhook server — validating that:
+//   - The webhook is correctly registered and called on WorkerDeployment create/update
+//   - The rules the CRD schema cannot express are enforced end-to-end:
+//       * Progressive rampPercentage must strictly increase between steps
+//       * gate.input and gate.inputFrom are mutually exclusive
+//   - Valid specs are admitted
+//
+// The webhook configuration is rendered from the Helm chart with webhook.enabled=true
+// (see webhook_suite_test.go), matching a real chart install with the flag on.
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// makeWDForWebhook builds a minimal WorkerDeployment that satisfies the CRD schema
+// (required: rollout, sunset, template, workerOptions) so admission reaches the webhook.
+func makeWDForWebhook(name, ns string) *WorkerDeployment {
+	scaledownDelay := metav1.Duration{Duration: time.Hour}
+	deleteDelay := metav1.Duration{Duration: 24 * time.Hour}
+	return &WorkerDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+		Spec: WorkerDeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": "test-worker"},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "worker", Image: "example.com/worker:v1"}},
+				},
+			},
+			RolloutStrategy: RolloutStrategy{Strategy: UpdateAllAtOnce},
+			SunsetStrategy: SunsetStrategy{
+				ScaledownDelay: &scaledownDelay,
+				DeleteDelay:    &deleteDelay,
+			},
+			WorkerOptions: WorkerOptions{
+				ConnectionRef:     ConnectionReference{Name: "test-connection"},
+				TemporalNamespace: "default",
+			},
+		},
+	}
+}
+
+var _ = Describe("WorkerDeployment validating webhook", func() {
+	It("admits a valid WorkerDeployment", func() {
+		ns := makeTestNamespace("wd-webhook-valid")
+		wd := makeWDForWebhook("valid-worker", ns)
+
+		Expect(k8sClient.Create(ctx, wd)).To(Succeed())
+		Expect(k8sClient.Delete(ctx, wd)).To(Succeed())
+	})
+
+	It("rejects Progressive rollout steps with non-increasing ramp percentages", func() {
+		ns := makeTestNamespace("wd-webhook-ramp")
+		wd := makeWDForWebhook("bad-ramp-worker", ns)
+		wd.Spec.RolloutStrategy.Strategy = UpdateProgressive
+		wd.Spec.RolloutStrategy.Steps = []RolloutStep{
+			{RampPercentage: 50, PauseDuration: metav1.Duration{Duration: time.Minute}},
+			{RampPercentage: 25, PauseDuration: metav1.Duration{Duration: time.Minute}},
+		}
+
+		err := k8sClient.Create(ctx, wd)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("rampPercentage must increase between each step"))
+	})
+
+	It("rejects a gate that sets both input and inputFrom", func() {
+		ns := makeTestNamespace("wd-webhook-gate")
+		wd := makeWDForWebhook("bad-gate-worker", ns)
+		wd.Spec.RolloutStrategy.Gate = &GateWorkflowConfig{
+			WorkflowType: "gate-workflow",
+			Input:        &apiextensionsv1.JSON{Raw: []byte(`{"key":"value"}`)},
+			InputFrom: &GateInputSource{
+				ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: "gate-input"},
+					Key:                  "input",
+				},
+			},
+		}
+
+		err := k8sClient.Create(ctx, wd)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("only one of input or inputFrom may be set"))
+	})
+
+	It("enforces the same rules on update", func() {
+		ns := makeTestNamespace("wd-webhook-update")
+		wd := makeWDForWebhook("update-worker", ns)
+		Expect(k8sClient.Create(ctx, wd)).To(Succeed())
+
+		wd.Spec.RolloutStrategy.Strategy = UpdateProgressive
+		wd.Spec.RolloutStrategy.Steps = []RolloutStep{
+			{RampPercentage: 30, PauseDuration: metav1.Duration{Duration: time.Minute}},
+			{RampPercentage: 30, PauseDuration: metav1.Duration{Duration: time.Minute}},
+		}
+
+		err := k8sClient.Update(ctx, wd)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("rampPercentage must increase between each step"))
+	})
+})

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -138,6 +138,10 @@ func main() {
 		setupLog.Error(err, "unable to create webhook", "webhook", "WorkerResourceTemplate")
 		os.Exit(1)
 	}
+	if err = (&temporaliov1alpha1.WorkerDeployment{}).SetupWebhookWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create webhook", "webhook", "WorkerDeployment")
+		os.Exit(1)
+	}
 	//+kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -138,7 +138,7 @@ func main() {
 		setupLog.Error(err, "unable to create webhook", "webhook", "WorkerResourceTemplate")
 		os.Exit(1)
 	}
-	if err = (&temporaliov1alpha1.WorkerDeployment{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&temporaliov1alpha1.WorkerDeployment{}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "WorkerDeployment")
 		os.Exit(1)
 	}


### PR DESCRIPTION
## What was changed

- Registered the `WorkerDeployment` admission webhook with the controller manager in `cmd/main.go`, next to the existing `WorkerResourceTemplateValidator` registration.
- Added integration tests that exercise the WorkerDeployment webhook through the real envtest admission path, using the `ValidatingWebhookConfiguration` rendered from the Helm chart with `--set webhook.enabled=true` (`api/v1alpha1/workerdeployment_webhook_integration_test.go`).
- Generalized the suite's chart-webhook loader (`loadWRTWebhookFromHelmChart` → `loadWebhookFromHelmChart(chartPath, webhookName, extraArgs...)`) so both webhook configurations are loaded from the chart.

## Why?

The Helm chart's `webhook.enabled` flag installs a `ValidatingWebhookConfiguration` (`vworkerdeployment.kb.io`) pointing at `/validate-temporal-io-v1alpha1-workerdeployment`, but no released binary (v1.0.0–v1.8.0, nor `main`) ever registered that handler. With the flag enabled, the webhook server answers HTTP 404 and — because the config uses `failurePolicy: Fail` — **every `WorkerDeployment` create/update is rejected**:

```
Internal error occurred: failed calling webhook "vworkerdeployment.kb.io":
failed to call webhook: the server could not find the requested resource
```

The handler itself has existed since v1.4.0 (`api/v1alpha1/workerdeployment_webhook.go`, with unit tests) — its registration was commented out pending TLS work (`// TODO(jlegrone): Enable the webhook after fixing TLS`) and the commented block was removed during the v1.5.x WorkerResourceTemplate work, while the chart kept shipping the flag and webhook template.

This change is low-risk:
- `webhook_suite_test.go` already performs this exact registration in the envtest manager, so the wired behavior was already tested — this aligns the production wiring with the tested path.
- With `webhook.enabled=false` (the default), no WorkerDeployment webhook config is installed, so the newly served path is never called — zero behavior change for default installs.
- The webhook server, port, and TLS serving cert already exist unconditionally for the always-on WorkerResourceTemplate webhook.

The new integration tests also close the gap that let this ship unnoticed: the suite previously installed only the WRT webhook config into envtest, so no test ever sent a `WorkerDeployment` through the kube-apiserver admission chain. (Note: they validate the chart-rendered config against the served path end-to-end, but cannot guard the `cmd/main.go` wiring itself — that would need an e2e test against the built binary.)

## Checklist

1. Closes #461 

2. How was this tested:

- New envtest integration specs (real kube-apiserver → webhook server admission requests, webhook config rendered from the Helm chart with `--set webhook.enabled=true`):
  - a valid `WorkerDeployment` is admitted
  - Progressive rollout steps with non-increasing `rampPercentage` are rejected on create and on update
  - a gate setting both `input` and `inputFrom` is rejected
- Full webhook suite passes locally: 15/15 specs (11 existing + 4 new).
- `go build ./...`, `go vet`, and the existing unit tests (`TestWorkerDeployment_*`) all pass.

3. Any docs updates needed?

No docs changes needed — this makes the behavior match what the chart's `values.yaml` already documents for `webhook.enabled` ("controls the optional WorkerDeployment validating webhook").