### PR TITLE
helm: add rbac.createEndUserRoles toggle to skip optional ClusterRoles

### DIFF
--- a/.github/workflows/helm-validate.yml
+++ b/.github/workflows/helm-validate.yml
@@ -54,6 +54,11 @@ jobs:
           helm template test-release helm/temporal-worker-controller \
             --set 'rbac.restrictWatchNamespaces={ns-a,ns-b}'
 
+      - name: Template with end user roles disabled
+        run: |
+          helm template test-release helm/temporal-worker-controller \
+            --set rbac.createEndUserRoles=false
+
   helm-lint-crds:
     name: Lint CRDs Chart
     runs-on: ubuntu-latest

--- a/helm/temporal-worker-controller/templates/rbac.yaml
+++ b/helm/temporal-worker-controller/templates/rbac.yaml
@@ -371,6 +371,7 @@ subjects:
     name: {{ .Values.serviceAccount.name | default (printf "%s-service-account" .Release.Name) }}
     namespace: {{ .Release.Namespace }}
 {{- end }}
+{{- if ne (.Values.rbac.createEndUserRoles | toString) "false" }}
 ---
 # permissions for end users to edit connections (new name).
 apiVersion: rbac.authorization.k8s.io/v1
@@ -632,5 +633,6 @@ rules:
       - workerresourcetemplates/status
     verbs:
       - get
+{{- end }}
 ---
 {{- end }}

--- a/helm/temporal-worker-controller/templates/rbac.yaml
+++ b/helm/temporal-worker-controller/templates/rbac.yaml
@@ -371,7 +371,7 @@ subjects:
     name: {{ .Values.serviceAccount.name | default (printf "%s-service-account" .Release.Name) }}
     namespace: {{ .Release.Namespace }}
 {{- end }}
-{{- if ne (.Values.rbac.createEndUserRoles | toString) "false" }}
+{{- if .Values.rbac.createEndUserRoles }}
 ---
 # permissions for end users to edit connections (new name).
 apiVersion: rbac.authorization.k8s.io/v1

--- a/helm/temporal-worker-controller/values.schema.json
+++ b/helm/temporal-worker-controller/values.schema.json
@@ -116,6 +116,10 @@
             "type": "string"
           },
           "description": "Namespaces the controller watches and is granted RBAC in. Empty (the default) watches all namespaces with cluster-wide RBAC (ClusterRole + ClusterRoleBinding); when set, the manager role is emitted as a namespaced Role (one per listed namespace) bound via a RoleBinding, plus a minimal cluster-scoped role for the two grants that cannot be namespaced (namespaces get, subjectaccessreviews create)."
+        },
+        "createEndUserRoles": {
+          "type": "boolean",
+          "description": "Whether to create the optional end-user editor/viewer ClusterRoles for temporal.io custom resources. These have no bindings by default and exist for cluster admins to bind as needed. Set to false to skip creating them."
         }
       }
     },

--- a/helm/temporal-worker-controller/values.yaml
+++ b/helm/temporal-worker-controller/values.yaml
@@ -51,7 +51,7 @@ rbac:
   # that grant end users permission to edit/view temporal.io custom resources
   # (connections, workerdeployments, workerresourcetemplates). These roles have no
   # bindings by default — they exist so cluster admins can bind them as needed.
-  # Set to false to skip creating them entirely
+  # Set to false to skip creating them entirely.
   createEndUserRoles: true
 
 serviceAccount:

--- a/helm/temporal-worker-controller/values.yaml
+++ b/helm/temporal-worker-controller/values.yaml
@@ -47,6 +47,12 @@ rbac:
   # via a RoleBinding, plus a minimal cluster-scoped role for the two grants that
   # cannot be namespaced (namespaces get, subjectaccessreviews create).
   restrictWatchNamespaces: []
+  # createEndUserRoles controls whether the chart creates the optional ClusterRoles
+  # that grant end users permission to edit/view temporal.io custom resources
+  # (connections, workerdeployments, workerresourcetemplates). These roles have no
+  # bindings by default — they exist so cluster admins can bind them as needed.
+  # Set to false to skip creating them entirely
+  createEndUserRoles: true
 
 serviceAccount:
   # Specifies whether a ServiceAccount should be created


### PR DESCRIPTION
## What

Adds `rbac.createEndUserRoles` (default: `true`) to control whether the chart creates the optional end-user editor/viewer ClusterRoles.

## Why

The chart creates 10 ClusterRoles granting end users edit/view access to the `temporal.io` custom resources — `connections`, `workerdeployments`, `workerresourcetemplates`, and their deprecated equivalents. These ship with no bindings; they exist so cluster admins can bind them as needed.

In environments with strict ClusterRole policies, unbound ClusterRoles draw review pushback even though they grant no access without an explicit binding. Right now the only way to avoid them is `rbac.create=false`, which also drops the roles the controller itself needs.

This is a follow-up to #450 (namespaced manager Role). Together the two let an operator run the controller with a minimal cluster-scoped footprint:

```
--set 'rbac.restrictWatchNamespaces={ns-a,ns-b}' --set rbac.createEndUserRoles=false
```

leaves only three ClusterRoles, all of them load-bearing: `metrics-reader`, `proxy-role`, `manager-cluster-role`.

## Changes

- `values.yaml` — new `rbac.createEndUserRoles` key, documented, defaults to `true`
- `templates/rbac.yaml` — guard around the 10 end-user ClusterRoles
- `values.schema.json` — schema entry for the new key
- `.github/workflows/helm-validate.yml` — template the chart with `createEndUserRoles=false`

Default behavior is unchanged.

## Verification

| Config | ClusterRoles rendered |
|---|---|
| default | 13 (3 functional + 10 end-user) |
| `createEndUserRoles=false` | 3 (`metrics-reader`, `proxy-role`, `manager-role`) |
| `createEndUserRoles=false` + `restrictWatchNamespaces` | 3 (manager perms as namespaced Roles) |
| `rbac.create=false` | 2 (`metrics-reader`, `proxy-role`) — unchanged |

- `helm lint --strict` passes with the toggle on and off
- Rendered output parses as valid YAML in both modes (no stray document separators from the conditional)
- `make manifests` leaves `templates/rbac.yaml` unchanged, so `helm-check-rbac` stays green