### PR TITLE
fix(clientpool): attach namespace header to every request

### DIFF
--- a/internal/controller/clientpool/clientpool.go
+++ b/internal/controller/clientpool/clientpool.go
@@ -114,14 +114,25 @@ type NewClientOptions struct {
 	Identity          string
 }
 
+type namespaceHeadersProvider string
+
+func (p namespaceHeadersProvider) GetHeaders(context.Context) (map[string]string, error) {
+	return map[string]string{"temporal-namespace": string(p)}, nil
+}
+
+func (cp *ClientPool) newClientOptions(opts NewClientOptions) sdkclient.Options {
+	return sdkclient.Options{
+		Logger:          cp.logger,
+		HostPort:        opts.Spec.HostPort,
+		Namespace:       opts.TemporalNamespace,
+		Identity:        opts.Identity,
+		HeadersProvider: namespaceHeadersProvider(opts.TemporalNamespace),
+	}
+}
+
 func (cp *ClientPool) fetchClientUsingMTLSSecret(secret corev1.Secret, opts NewClientOptions) (*sdkclient.Options, *ClientPoolKey, *ClientAuth, error) {
 	tlsServerName := opts.Spec.TLSServerName()
-	clientOpts := sdkclient.Options{
-		Logger:    cp.logger,
-		HostPort:  opts.Spec.HostPort,
-		Namespace: opts.TemporalNamespace,
-		Identity:  opts.Identity,
-	}
+	clientOpts := cp.newClientOptions(opts)
 
 	var pemCert []byte
 	var expiryTime time.Time
@@ -186,15 +197,8 @@ func (cp *ClientPool) fetchClientUsingMTLSSecret(secret corev1.Secret, opts NewC
 
 func (cp *ClientPool) fetchClientUsingAPIKeySecret(opts NewClientOptions) (*sdkclient.Options, *ClientPoolKey, *ClientAuth, error) {
 	tlsServerName := opts.Spec.TLSServerName()
-	clientOpts := sdkclient.Options{
-		Logger:    cp.logger,
-		HostPort:  opts.Spec.HostPort,
-		Namespace: opts.TemporalNamespace,
-		Identity:  opts.Identity,
-		ConnectionOptions: sdkclient.ConnectionOptions{
-			TLS: &tls.Config{ServerName: tlsServerName},
-		},
-	}
+	clientOpts := cp.newClientOptions(opts)
+	clientOpts.ConnectionOptions.TLS = &tls.Config{ServerName: tlsServerName}
 
 	secretName := opts.Spec.APIKeySecretRef.Name
 	secretKey := opts.Spec.APIKeySecretRef.Key
@@ -220,12 +224,7 @@ func (cp *ClientPool) fetchClientUsingAPIKeySecret(opts NewClientOptions) (*sdkc
 
 func (cp *ClientPool) fetchClientUsingNoCredentials(opts NewClientOptions) (*sdkclient.Options, *ClientPoolKey, *ClientAuth, error) {
 	tlsServerName := opts.Spec.TLSServerName()
-	clientOpts := sdkclient.Options{
-		Logger:    cp.logger,
-		HostPort:  opts.Spec.HostPort,
-		Namespace: opts.TemporalNamespace,
-		Identity:  opts.Identity,
-	}
+	clientOpts := cp.newClientOptions(opts)
 	if tlsServerName != "" {
 		clientOpts.ConnectionOptions.TLS = &tls.Config{ServerName: tlsServerName}
 	}

--- a/internal/controller/clientpool/clientpool_test.go
+++ b/internal/controller/clientpool/clientpool_test.go
@@ -104,6 +104,19 @@ func makeOpts(hostPort string) NewClientOptions {
 	}
 }
 
+func TestNewClientOptionsSetsTemporalNamespaceHeader(t *testing.T) {
+	opts := makeOpts("localhost:7233")
+	opts.TemporalNamespace = "routing-namespace"
+	clientOpts := newTestPool().newClientOptions(opts)
+
+	headers, err := clientOpts.HeadersProvider.GetHeaders(context.Background())
+
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{
+		"temporal-namespace": "routing-namespace",
+	}, headers)
+}
+
 func makeTLSSecret(certPEM, keyPEM, caPEM []byte) corev1.Secret {
 	data := map[string][]byte{
 		"tls.crt": certPEM,

--- a/internal/controller/clientpool/clientpool_test.go
+++ b/internal/controller/clientpool/clientpool_test.go
@@ -109,7 +109,7 @@ func TestNewClientOptionsSetsTemporalNamespaceHeader(t *testing.T) {
 	opts.TemporalNamespace = "routing-namespace"
 	clientOpts := newTestPool().newClientOptions(opts)
 
-	headers, err := clientOpts.HeadersProvider.GetHeaders(context.Background())
+	headers, err := clientOpts.HeadersProvider.GetHeaders(t.Context())
 
 	require.NoError(t, err)
 	assert.Equal(t, map[string]string{


### PR DESCRIPTION
## Summary

Attach the `temporal-namespace` header through the SDK header provider so it is included on every request, including `GetSystemInfo`. All authentication modes now share the same base client options.

Fixes #440.

## What was verified

- `go test ./internal/controller/clientpool -count=1`
- `go vet ./internal/controller/clientpool`
