### PR TITLE
feat(helm): configure kube-rbac-proxy sidecar

### DIFF
--- a/.github/workflows/helm-validate.yml
+++ b/.github/workflows/helm-validate.yml
@@ -51,15 +51,11 @@ jobs:
 
       - name: Template with kube-rbac-proxy image override
         run: |
-          rendered_chart="$(mktemp)"
           helm template test-release helm/temporal-worker-controller \
             --set kubeRBACProxy.image.registry=example.invalid \
             --set kubeRBACProxy.image.repository=kube-rbac-proxy \
             --set kubeRBACProxy.image.tag=test \
-            --set kubeRBACProxy.image.pullPolicy=Always \
-            > "$rendered_chart"
-          grep -F 'image: "example.invalid/kube-rbac-proxy:test"' "$rendered_chart"
-          grep -F 'imagePullPolicy: Always' "$rendered_chart"
+            --set kubeRBACProxy.image.pullPolicy=Always
 
       - name: Template with restricted watch namespaces
         run: |

--- a/.github/workflows/helm-validate.yml
+++ b/.github/workflows/helm-validate.yml
@@ -49,6 +49,13 @@ jobs:
           helm template test-release helm/temporal-worker-controller \
             --set metrics.disableAuth=true
 
+      - name: Template with kube-rbac-proxy image override
+        run: |
+          helm template test-release helm/temporal-worker-controller \
+            --set metrics.kubeRbacProxy.image.repository=example.invalid/kube-rbac-proxy \
+            --set metrics.kubeRbacProxy.image.tag=test \
+            --set metrics.kubeRbacProxy.image.pullPolicy=Always
+
       - name: Template with restricted watch namespaces
         run: |
           helm template test-release helm/temporal-worker-controller \

--- a/.github/workflows/helm-validate.yml
+++ b/.github/workflows/helm-validate.yml
@@ -52,9 +52,10 @@ jobs:
       - name: Template with kube-rbac-proxy image override
         run: |
           helm template test-release helm/temporal-worker-controller \
-            --set metrics.kubeRbacProxy.image.repository=example.invalid/kube-rbac-proxy \
-            --set metrics.kubeRbacProxy.image.tag=test \
-            --set metrics.kubeRbacProxy.image.pullPolicy=Always
+            --set kubeRBACProxy.image.registry=example.invalid \
+            --set kubeRBACProxy.image.repository=kube-rbac-proxy \
+            --set kubeRBACProxy.image.tag=test \
+            --set kubeRBACProxy.image.pullPolicy=Always
 
       - name: Template with restricted watch namespaces
         run: |

--- a/.github/workflows/helm-validate.yml
+++ b/.github/workflows/helm-validate.yml
@@ -51,11 +51,15 @@ jobs:
 
       - name: Template with kube-rbac-proxy image override
         run: |
+          rendered_chart="$(mktemp)"
           helm template test-release helm/temporal-worker-controller \
             --set kubeRBACProxy.image.registry=example.invalid \
             --set kubeRBACProxy.image.repository=kube-rbac-proxy \
             --set kubeRBACProxy.image.tag=test \
-            --set kubeRBACProxy.image.pullPolicy=Always
+            --set kubeRBACProxy.image.pullPolicy=Always \
+            > "$rendered_chart"
+          grep -F 'image: "example.invalid/kube-rbac-proxy:test"' "$rendered_chart"
+          grep -F 'imagePullPolicy: Always' "$rendered_chart"
 
       - name: Template with restricted watch namespaces
         run: |

--- a/helm/temporal-worker-controller/templates/_helpers.tpl
+++ b/helm/temporal-worker-controller/templates/_helpers.tpl
@@ -20,6 +20,17 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+kube-rbac-proxy image reference. A digest takes precedence over a tag when set.
+*/}}
+{{- define "temporal-worker-controller.kubeRBACProxyImage" -}}
+{{- if .Values.kubeRBACProxy.image.sha -}}
+{{ printf "%s/%s@%s" .Values.kubeRBACProxy.image.registry .Values.kubeRBACProxy.image.repository .Values.kubeRBACProxy.image.sha }}
+{{- else -}}
+{{ printf "%s/%s:%s" .Values.kubeRBACProxy.image.registry .Values.kubeRBACProxy.image.repository .Values.kubeRBACProxy.image.tag }}
+{{- end -}}
+{{- end }}
+
+{{/*
 Namespace selector restricting admission webhooks to the watched namespaces.
 Rendered only when rbac.restrictWatchNamespaces is set; keys off the
 kubernetes.io/metadata.name label the API server sets on every namespace.

--- a/helm/temporal-worker-controller/templates/manager.yaml
+++ b/helm/temporal-worker-controller/templates/manager.yaml
@@ -161,7 +161,8 @@ spec:
             drop:
               - "ALL"
         {{- end }}
-        image: registry.k8s.io/kubebuilder/kube-rbac-proxy:v0.14.1
+        image: "{{ .Values.metrics.kubeRbacProxy.image.repository }}:{{ .Values.metrics.kubeRbacProxy.image.tag }}"
+        imagePullPolicy: {{ .Values.metrics.kubeRbacProxy.image.pullPolicy }}
         args:
           - "--secure-listen-address=0.0.0.0:8443"
           - --upstream=http://127.0.0.1:{{ .Values.metrics.port }}/

--- a/helm/temporal-worker-controller/templates/manager.yaml
+++ b/helm/temporal-worker-controller/templates/manager.yaml
@@ -151,7 +151,10 @@ spec:
           {{- toYaml .Values.resources | nindent 10 }}
       {{- if not .Values.metrics.disableAuth }}
       - name: kube-rbac-proxy
-        {{- if .Values.containerSecurityContext }}
+        {{- if .Values.kubeRBACProxy.containerSecurityContext }}
+        securityContext:
+          {{- toYaml .Values.kubeRBACProxy.containerSecurityContext | nindent 10 }}
+        {{- else if .Values.containerSecurityContext }}
         securityContext:
           {{- toYaml .Values.containerSecurityContext | nindent 10 }}
         {{- else }}
@@ -161,24 +164,26 @@ spec:
             drop:
               - "ALL"
         {{- end }}
-        image: "{{ .Values.metrics.kubeRbacProxy.image.repository }}:{{ .Values.metrics.kubeRbacProxy.image.tag }}"
-        imagePullPolicy: {{ .Values.metrics.kubeRbacProxy.image.pullPolicy }}
+        image: {{ include "temporal-worker-controller.kubeRBACProxyImage" . | quote }}
+        imagePullPolicy: {{ .Values.kubeRBACProxy.image.pullPolicy }}
         args:
           - "--secure-listen-address=0.0.0.0:8443"
           - --upstream=http://127.0.0.1:{{ .Values.metrics.port }}/
           - "--logtostderr=true"
           - "--v=0"
+        {{- with .Values.kubeRBACProxy.extraArgs }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         ports:
           - containerPort: 8443
             protocol: TCP
             name: https
+        {{- with .Values.kubeRBACProxy.volumeMounts }}
+        volumeMounts:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         resources:
-          limits:
-            cpu: 500m
-            memory: 128Mi
-          requests:
-            cpu: 5m
-            memory: 64Mi
+          {{- toYaml .Values.kubeRBACProxy.resources | nindent 10 }}
       {{- end }}
       volumes:
         - name: cert

--- a/helm/temporal-worker-controller/values.schema.json
+++ b/helm/temporal-worker-controller/values.schema.json
@@ -41,6 +41,64 @@
         }
       }
     },
+    "kubeRBACProxy": {
+      "type": "object",
+      "description": "Configuration for the kube-rbac-proxy metrics sidecar",
+      "properties": {
+        "image": {
+          "type": "object",
+          "properties": {
+            "registry": {
+              "type": "string",
+              "description": "kube-rbac-proxy image registry"
+            },
+            "repository": {
+              "type": "string",
+              "description": "kube-rbac-proxy image repository"
+            },
+            "tag": {
+              "type": "string",
+              "description": "kube-rbac-proxy image tag"
+            },
+            "sha": {
+              "type": "string",
+              "description": "Optional kube-rbac-proxy image digest"
+            },
+            "pullPolicy": {
+              "type": "string",
+              "enum": [
+                "Always",
+                "IfNotPresent",
+                "Never"
+              ],
+              "description": "kube-rbac-proxy image pull policy"
+            }
+          }
+        },
+        "extraArgs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Additional kube-rbac-proxy arguments"
+        },
+        "containerSecurityContext": {
+          "type": "object",
+          "description": "kube-rbac-proxy container security context"
+        },
+        "resources": {
+          "type": "object",
+          "description": "kube-rbac-proxy resource requirements"
+        },
+        "volumeMounts": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          },
+          "description": "Additional kube-rbac-proxy volume mounts"
+        }
+      }
+    },
     "podAnnotations": {
       "type": "object",
       "description": "Additional pod annotations",
@@ -180,33 +238,6 @@
           "minimum": 1,
           "maximum": 65535,
           "description": "Port for metrics endpoint"
-        },
-        "kubeRbacProxy": {
-          "type": "object",
-          "properties": {
-            "image": {
-              "type": "object",
-              "properties": {
-                "repository": {
-                  "type": "string",
-                  "description": "kube-rbac-proxy image repository"
-                },
-                "tag": {
-                  "type": "string",
-                  "description": "kube-rbac-proxy image tag"
-                },
-                "pullPolicy": {
-                  "type": "string",
-                  "enum": [
-                    "Always",
-                    "IfNotPresent",
-                    "Never"
-                  ],
-                  "description": "kube-rbac-proxy image pull policy"
-                }
-              }
-            }
-          }
         },
         "disableAuth": {
           "type": "boolean",

--- a/helm/temporal-worker-controller/values.schema.json
+++ b/helm/temporal-worker-controller/values.schema.json
@@ -41,64 +41,6 @@
         }
       }
     },
-    "kubeRBACProxy": {
-      "type": "object",
-      "description": "Configuration for the kube-rbac-proxy metrics sidecar",
-      "properties": {
-        "image": {
-          "type": "object",
-          "properties": {
-            "registry": {
-              "type": "string",
-              "description": "kube-rbac-proxy image registry"
-            },
-            "repository": {
-              "type": "string",
-              "description": "kube-rbac-proxy image repository"
-            },
-            "tag": {
-              "type": "string",
-              "description": "kube-rbac-proxy image tag"
-            },
-            "sha": {
-              "type": "string",
-              "description": "Optional kube-rbac-proxy image digest"
-            },
-            "pullPolicy": {
-              "type": "string",
-              "enum": [
-                "Always",
-                "IfNotPresent",
-                "Never"
-              ],
-              "description": "kube-rbac-proxy image pull policy"
-            }
-          }
-        },
-        "extraArgs": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Additional kube-rbac-proxy arguments"
-        },
-        "containerSecurityContext": {
-          "type": "object",
-          "description": "kube-rbac-proxy container security context"
-        },
-        "resources": {
-          "type": "object",
-          "description": "kube-rbac-proxy resource requirements"
-        },
-        "volumeMounts": {
-          "type": "array",
-          "items": {
-            "type": "object"
-          },
-          "description": "Additional kube-rbac-proxy volume mounts"
-        }
-      }
-    },
     "podAnnotations": {
       "type": "object",
       "description": "Additional pod annotations",
@@ -315,6 +257,64 @@
       "default": 1,
       "description": "Number of replicas of manager to run.\n\nThe default is 1, but in production set this to 2 or 3 to provide high availability.",
       "type": "number"
+    },
+    "kubeRBACProxy": {
+      "type": "object",
+      "description": "Configuration for the kube-rbac-proxy metrics sidecar",
+      "properties": {
+        "image": {
+          "type": "object",
+          "properties": {
+            "registry": {
+              "type": "string",
+              "description": "kube-rbac-proxy image registry"
+            },
+            "repository": {
+              "type": "string",
+              "description": "kube-rbac-proxy image repository"
+            },
+            "tag": {
+              "type": "string",
+              "description": "kube-rbac-proxy image tag"
+            },
+            "sha": {
+              "type": "string",
+              "description": "Optional kube-rbac-proxy image digest"
+            },
+            "pullPolicy": {
+              "type": "string",
+              "enum": [
+                "Always",
+                "IfNotPresent",
+                "Never"
+              ],
+              "description": "kube-rbac-proxy image pull policy"
+            }
+          }
+        },
+        "extraArgs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Additional kube-rbac-proxy arguments"
+        },
+        "containerSecurityContext": {
+          "type": "object",
+          "description": "kube-rbac-proxy container security context"
+        },
+        "resources": {
+          "type": "object",
+          "description": "kube-rbac-proxy resource requirements"
+        },
+        "volumeMounts": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          },
+          "description": "Additional kube-rbac-proxy volume mounts"
+        }
+      }
     }
   }
 }

--- a/helm/temporal-worker-controller/values.schema.json
+++ b/helm/temporal-worker-controller/values.schema.json
@@ -181,6 +181,33 @@
           "maximum": 65535,
           "description": "Port for metrics endpoint"
         },
+        "kubeRbacProxy": {
+          "type": "object",
+          "properties": {
+            "image": {
+              "type": "object",
+              "properties": {
+                "repository": {
+                  "type": "string",
+                  "description": "kube-rbac-proxy image repository"
+                },
+                "tag": {
+                  "type": "string",
+                  "description": "kube-rbac-proxy image tag"
+                },
+                "pullPolicy": {
+                  "type": "string",
+                  "enum": [
+                    "Always",
+                    "IfNotPresent",
+                    "Never"
+                  ],
+                  "description": "kube-rbac-proxy image pull policy"
+                }
+              }
+            }
+          }
+        },
         "disableAuth": {
           "type": "boolean",
           "description": "Whether to disable authentication for metrics endpoint"

--- a/helm/temporal-worker-controller/values.yaml
+++ b/helm/temporal-worker-controller/values.yaml
@@ -110,31 +110,6 @@ replicas: 2
 authProxy:
   enabled: true
 
-# Configure the kube-rbac-proxy sidecar that protects the controller metrics
-# endpoint. The sidecar is enabled unless metrics.disableAuth is true.
-kubeRBACProxy:
-  image:
-    registry: registry.k8s.io
-    repository: kubebuilder/kube-rbac-proxy
-    tag: v0.14.1
-    sha: ""
-    pullPolicy: IfNotPresent
-  # Additional arguments for kube-rbac-proxy.
-  extraArgs: []
-  # Overrides the global containerSecurityContext for this sidecar only.
-  # When empty, the global containerSecurityContext remains the fallback.
-  containerSecurityContext: {}
-  resources:
-    limits:
-      cpu: 500m
-      memory: 128Mi
-    requests:
-      cpu: 5m
-      memory: 64Mi
-  # Additional volume mounts for kube-rbac-proxy. Volumes must be supplied by
-  # the chart or another supported configuration option.
-  volumeMounts: []
-
 metrics:
   enabled: true
   port: 8080
@@ -209,3 +184,28 @@ prometheus:
 nodeSelector: {}
 
 tolerations: []
+
+# Configure the kube-rbac-proxy sidecar that protects the controller metrics
+# endpoint. The sidecar is enabled unless metrics.disableAuth is true.
+kubeRBACProxy:
+  image:
+    registry: registry.k8s.io
+    repository: kubebuilder/kube-rbac-proxy
+    tag: v0.14.1
+    sha: ""
+    pullPolicy: IfNotPresent
+  # Additional arguments for kube-rbac-proxy.
+  extraArgs: []
+  # Overrides the global containerSecurityContext for this sidecar only.
+  # When empty, the global containerSecurityContext remains the fallback.
+  containerSecurityContext: {}
+  resources:
+    limits:
+      cpu: 500m
+      memory: 128Mi
+    requests:
+      cpu: 5m
+      memory: 64Mi
+  # Additional volume mounts for kube-rbac-proxy. Volumes must be supplied by
+  # the chart or another supported configuration option.
+  volumeMounts: []

--- a/helm/temporal-worker-controller/values.yaml
+++ b/helm/temporal-worker-controller/values.yaml
@@ -113,6 +113,13 @@ authProxy:
 metrics:
   enabled: true
   port: 8080
+  # Image configuration for the authenticated metrics sidecar. Configure this
+  # when mirroring kube-rbac-proxy to a private registry.
+  kubeRbacProxy:
+    image:
+      repository: registry.k8s.io/kubebuilder/kube-rbac-proxy
+      tag: v0.14.1
+      pullPolicy: IfNotPresent
   # Set to true if you want your controller-manager to expose the /metrics
   # endpoint w/o any authn/z.
   #

--- a/helm/temporal-worker-controller/values.yaml
+++ b/helm/temporal-worker-controller/values.yaml
@@ -110,16 +110,34 @@ replicas: 2
 authProxy:
   enabled: true
 
+# Configure the kube-rbac-proxy sidecar that protects the controller metrics
+# endpoint. The sidecar is enabled unless metrics.disableAuth is true.
+kubeRBACProxy:
+  image:
+    registry: registry.k8s.io
+    repository: kubebuilder/kube-rbac-proxy
+    tag: v0.14.1
+    sha: ""
+    pullPolicy: IfNotPresent
+  # Additional arguments for kube-rbac-proxy.
+  extraArgs: []
+  # Overrides the global containerSecurityContext for this sidecar only.
+  # When empty, the global containerSecurityContext remains the fallback.
+  containerSecurityContext: {}
+  resources:
+    limits:
+      cpu: 500m
+      memory: 128Mi
+    requests:
+      cpu: 5m
+      memory: 64Mi
+  # Additional volume mounts for kube-rbac-proxy. Volumes must be supplied by
+  # the chart or another supported configuration option.
+  volumeMounts: []
+
 metrics:
   enabled: true
   port: 8080
-  # Image configuration for the authenticated metrics sidecar. Configure this
-  # when mirroring kube-rbac-proxy to a private registry.
-  kubeRbacProxy:
-    image:
-      repository: registry.k8s.io/kubebuilder/kube-rbac-proxy
-      tag: v0.14.1
-      pullPolicy: IfNotPresent
   # Set to true if you want your controller-manager to expose the /metrics
   # endpoint w/o any authn/z.
   #


### PR DESCRIPTION
## What was changed

Adds a top-level `kubeRBACProxy` configuration block for the authenticated
metrics sidecar. It supports configuring:

- Image registry, repository, tag, optional digest, and pull policy
- Additional arguments
- Sidecar-specific resource requirements
- Sidecar-specific security context
- Additional volume mounts

The default configuration preserves the existing rendered sidecar image,
security controls, resource requirements, and pull policy. The existing global
`containerSecurityContext` remains a fallback when a proxy-specific context is
not set.

## Why?

Users who mirror third-party images into private registries need to configure
the kube-rbac-proxy sidecar independently of the controller image. This enables
security scanning, patch management, and restricted-network deployments without
requiring a fork of the chart.

The top-level `kubeRBACProxy` API follows the established kube-state-metrics
Helm chart convention while retaining this chart's existing
`metrics.disableAuth` setting as the single control for whether the sidecar is
injected.

## Checklist

1. Closes #460

2. How was this tested:

   ```bash
   helm repo add jetstack https://charts.jetstack.io
   helm dependency build helm/temporal-worker-controller
   helm lint --strict helm/temporal-worker-controller
   helm template test-release helm/temporal-worker-controller
   helm template test-release helm/temporal-worker-controller \
     --set kubeRBACProxy.image.registry=example.invalid \
     --set kubeRBACProxy.image.repository=kube-rbac-proxy \
     --set kubeRBACProxy.image.tag=test \
     --set kubeRBACProxy.image.pullPolicy=Always
   ```

   Also verified the digest image path and that the existing global
   `containerSecurityContext` remains the fallback for the sidecar.

3. Any docs updates needed?

   No external documentation update is needed. The supported values are
   documented in the chart's `values.yaml` and validated by
   `values.schema.json`.
