### PR TITLE
tell dependabot to ignore cert-manager dep in Helm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,11 @@ updates:
       interval: weekly
     cooldown:
       default-days: 14
+    ignore:
+      # We are deliberate about updating cert-manager dependency in our Helm
+      # chart. Keep this at >=1.0.0 and instruct dependabot to ignore this
+      # dependency in our Chart.yaml file.
+      - dependency-name: "cert-manager"
 
   - package-ecosystem: github-actions
     directory: "/"


### PR DESCRIPTION
Tells Dependabot to stop creating version update PRs for the cert-manager Helm Chart dependency. That dependency is currently set to `>=1.0.0` which is fine and Dependabot [continually tries][0] to set it to a specific semver release -- e.g. `1.21.1`. I've asked dependabot in PR comments to ignore this dependency, but it is not responding to my comments.

[0]: https://github.com/temporalio/temporal-worker-controller/pull/482