### PR TITLE
chore: added workflow for changelog file

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -1,0 +1,46 @@
+name: Update Changelog
+
+on:
+  release:
+    types: [published]
+  # Allow manual runs for a specific tag.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to generate the changelog entry for"
+        required: false
+        default: ""
+      mode:
+        description:
+          prepend (this tag only) or full (regenerate from all tags).
+          Tag is REQUIRED only if mode is prepend. full mode will
+          regenerate the entire file and WILL DISCARD any manual edits.
+        type: choice
+        options:
+          - prepend
+          - full
+
+permissions:
+  contents: write
+  pull-requests: write # required to open the changelog PR with github-actions[bot]
+
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Full history + tags are required to diff between releases.
+          fetch-depth: 0
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Update changelog
+        uses: shazib-summar/automated-changelog-gh@v0.2.0
+        with:
+          # see inputs at https://github.com/shazib-summar/automated-changelog-gh#inputs
+          tag: ${{ github.event.inputs.tag }}
+          mode: ${{ github.event.inputs.mode || 'prepend' }}
+          pull-request: true
+          pr-labels: changelog,docs,automated
+          reviewers: jaypipes

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -11,8 +11,7 @@ on:
         required: false
         default: ""
       mode:
-        description:
-          prepend (this tag only) or full (regenerate from all tags).
+        description: prepend (this tag only) or full (regenerate from all tags).
           Tag is REQUIRED only if mode is prepend. full mode will
           regenerate the entire file and WILL DISCARD any manual edits.
         type: choice
@@ -29,18 +28,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
         with:
           # Full history + tags are required to diff between releases.
           fetch-depth: 0
           ref: ${{ github.event.repository.default_branch }}
 
       - name: Update changelog
-        uses: shazib-summar/automated-changelog-gh@v0.2.0
+        uses: shazib-summar/automated-changelog-gh@05d6ccc344bc518f859e830a72137fb58616fb71 #v0.2.0
         with:
           # see inputs at https://github.com/shazib-summar/automated-changelog-gh#inputs
           tag: ${{ github.event.inputs.tag }}
           mode: ${{ github.event.inputs.mode || 'prepend' }}
           pull-request: true
           pr-labels: changelog,docs,automated
-          reviewers: jaypipes
+          reviewers: temporalio/worker-controller

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
+.vscode
 
 bin
 dist


### PR DESCRIPTION
<!--- For ALL Contributors 👇 -->

## What was changed
This commit introduces a github actions workflow to introduce a CHANGELOG.md file that is automatically updated when a new GitHub release is published in this repo. The automated-changelog-gh action is added in `prepend` mode i.e. when triggered through a release publishing it will prepend the CHANGELOG.md file with the changelog for the latest release. This ensure any manual changes are reserved but requires us to instantiate a CHANGELOG.md file with the changelog for previous releases backfilled.

This can be simply done by heading over to the Actions tab in the repo and running it manually for the first time with mode set to `full`.

The `github-actions[bot]` will always open a PR instead of pushing commit directly to the default branch.

## Why?
To maintain a changelog little to none maintenance.

1. Closes https://github.com/temporalio/temporal-worker-controller/issues/296

2. How was this tested:
Tested in my fork.
See the commits in this branch: https://github.com/temporalio/temporal-worker-controller/compare/main...shazib-summar:temporal-worker-controller:automated-changelog-test
See these PRs as an example of what this bot is intended to do: https://github.com/shazib-summar/temporal-worker-controller/pull/6 and https://github.com/shazib-summar/temporal-worker-controller/pull/4

3. Any docs updates needed?
No
