### PR TITLE
feat: allow RollingUpdate to be specified for k8s Deployment

### DIFF
--- a/api/v1alpha1/deployment_strategy.go
+++ b/api/v1alpha1/deployment_strategy.go
@@ -1,0 +1,94 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2024 Datadog, Inc.
+
+package v1alpha1
+
+import (
+	"fmt"
+
+	"github.com/temporalio/temporal-worker-controller/internal/defaults"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+// DefaultDeploymentStrategy returns a deep copy of s with unset fields filled
+// using the same defaults as the apps/v1 Deployment API. The input is never
+// mutated. A nil input returns nil.
+func DefaultDeploymentStrategy(s *appsv1.DeploymentStrategy) *appsv1.DeploymentStrategy {
+	if s == nil {
+		return nil
+	}
+	out := s.DeepCopy()
+	if out.Type == "" {
+		out.Type = appsv1.RollingUpdateDeploymentStrategyType
+	}
+	if out.Type == appsv1.RollingUpdateDeploymentStrategyType {
+		if out.RollingUpdate == nil {
+			out.RollingUpdate = &appsv1.RollingUpdateDeployment{}
+		}
+		if out.RollingUpdate.MaxUnavailable == nil {
+			maxUnavailable := intstr.FromString(defaults.DeploymentMaxUnavailable)
+			out.RollingUpdate.MaxUnavailable = &maxUnavailable
+		}
+		if out.RollingUpdate.MaxSurge == nil {
+			maxSurge := intstr.FromString(defaults.DeploymentMaxSurge)
+			out.RollingUpdate.MaxSurge = &maxSurge
+		}
+	}
+	return out
+}
+
+// validateDeploymentStrategy checks constraints that the CRD schema cannot
+// enforce for spec.deploymentStrategy.
+func validateDeploymentStrategy(s *appsv1.DeploymentStrategy) []*field.Error {
+	if s == nil {
+		return nil
+	}
+
+	var allErrs []*field.Error
+	path := field.NewPath("spec.deploymentStrategy")
+
+	switch s.Type {
+	case "", appsv1.RollingUpdateDeploymentStrategyType, appsv1.RecreateDeploymentStrategyType:
+	default:
+		allErrs = append(allErrs, field.NotSupported(
+			path.Child("type"),
+			s.Type,
+			[]string{
+				string(appsv1.RollingUpdateDeploymentStrategyType),
+				string(appsv1.RecreateDeploymentStrategyType),
+			},
+		))
+	}
+
+	if s.Type == appsv1.RecreateDeploymentStrategyType && s.RollingUpdate != nil {
+		allErrs = append(allErrs, field.Forbidden(
+			path.Child("rollingUpdate"),
+			"may not be set when type is Recreate",
+		))
+	}
+
+	if s.RollingUpdate != nil &&
+		isExplicitlyZeroIntOrString(s.RollingUpdate.MaxUnavailable) &&
+		isExplicitlyZeroIntOrString(s.RollingUpdate.MaxSurge) {
+		allErrs = append(allErrs, field.Invalid(
+			path.Child("rollingUpdate"),
+			fmt.Sprintf("maxUnavailable=%v, maxSurge=%v", s.RollingUpdate.MaxUnavailable, s.RollingUpdate.MaxSurge),
+			"maxUnavailable and maxSurge cannot both be 0",
+		))
+	}
+
+	return allErrs
+}
+
+func isExplicitlyZeroIntOrString(v *intstr.IntOrString) bool {
+	if v == nil {
+		return false
+	}
+	if v.Type == intstr.Int {
+		return v.IntVal == 0
+	}
+	return v.StrVal == "0" || v.StrVal == "0%"
+}

--- a/api/v1alpha1/deployment_strategy_test.go
+++ b/api/v1alpha1/deployment_strategy_test.go
@@ -1,0 +1,32 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2024 Datadog, Inc.
+
+package v1alpha1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/temporalio/temporal-worker-controller/internal/defaults"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func TestDefaultDeploymentStrategy_DoesNotMutateInput(t *testing.T) {
+	maxUnavailable := intstr.FromString("5%")
+	rollingUpdate := &appsv1.RollingUpdateDeployment{
+		MaxUnavailable: &maxUnavailable,
+	}
+	in := &appsv1.DeploymentStrategy{RollingUpdate: rollingUpdate}
+
+	out := DefaultDeploymentStrategy(in)
+	require.NotNil(t, out)
+	assert.Equal(t, appsv1.RollingUpdateDeploymentStrategyType, out.Type)
+	require.NotNil(t, out.RollingUpdate.MaxSurge)
+	assert.Equal(t, intstr.FromString(defaults.DeploymentMaxSurge), *out.RollingUpdate.MaxSurge)
+
+	assert.Nil(t, rollingUpdate.MaxSurge, "input RollingUpdate must not be mutated")
+	assert.Empty(t, in.Type, "input Type must not be mutated")
+}

--- a/api/v1alpha1/workerdeployment_types.go
+++ b/api/v1alpha1/workerdeployment_types.go
@@ -87,11 +87,7 @@ type WorkerDeploymentSpec struct {
 	// maxUnavailable/maxSurge 25%).
 	//
 	// This is distinct from spec.rollout.strategy, which controls Temporal
-	// traffic routing across worker versions. It also does not apply when the
-	// controller creates a new build ID / Deployment for a new worker version.
-	// It matters for in-place pod replacement on an existing version Deployment
-	// (for example kubectl rollout restart, or a pod-template change while
-	// spec.workerOptions.unsafeCustomBuildID stays the same).
+	// traffic routing across worker versions.
 	// +optional
 	DeploymentStrategy *appsv1.DeploymentStrategy `json:"deploymentStrategy,omitempty"`
 

--- a/api/v1alpha1/workerdeployment_types.go
+++ b/api/v1alpha1/workerdeployment_types.go
@@ -5,6 +5,7 @@
 package v1alpha1
 
 import (
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -79,6 +80,20 @@ type WorkerDeploymentSpec struct {
 	// not be estimated during the time a deployment is paused. Defaults to 600s.
 	// +kubebuilder:default=600
 	ProgressDeadlineSeconds *int32 `json:"progressDeadlineSeconds,omitempty" protobuf:"varint,9,opt,name=progressDeadlineSeconds"`
+
+	// DeploymentStrategy describes how to replace Pods within each versioned
+	// Deployment this controller owns. Mirrors apps/v1 Deployment.spec.strategy.
+	// When omitted, Kubernetes defaults apply (RollingUpdate with
+	// maxUnavailable/maxSurge 25%).
+	//
+	// This is distinct from spec.rollout.strategy, which controls Temporal
+	// traffic routing across worker versions. It also does not apply when the
+	// controller creates a new build ID / Deployment for a new worker version.
+	// It matters for in-place pod replacement on an existing version Deployment
+	// (for example kubectl rollout restart, or a pod-template change while
+	// spec.workerOptions.unsafeCustomBuildID stays the same).
+	// +optional
+	DeploymentStrategy *appsv1.DeploymentStrategy `json:"deploymentStrategy,omitempty"`
 
 	// How to rollout new workflow executions to the target version.
 	RolloutStrategy RolloutStrategy `json:"rollout"`

--- a/api/v1alpha1/workerdeployment_webhook.go
+++ b/api/v1alpha1/workerdeployment_webhook.go
@@ -53,6 +53,10 @@ func (s *WorkerDeploymentSpec) Default(ctx context.Context) error {
 		s.SunsetStrategy.DeleteDelay = &v1.Duration{Duration: defaults.DeleteDelay}
 	}
 
+	if s.DeploymentStrategy != nil {
+		s.DeploymentStrategy = DefaultDeploymentStrategy(s.DeploymentStrategy)
+	}
+
 	return nil
 }
 
@@ -82,6 +86,7 @@ func (r *WorkerDeployment) validateForUpdateOrCreate(ctx context.Context, obj ru
 
 func validateForUpdateOrCreate(old, new *WorkerDeployment) (admission.Warnings, error) {
 	allErrs := validateRolloutStrategy(new.Spec.RolloutStrategy)
+	allErrs = append(allErrs, validateDeploymentStrategy(new.Spec.DeploymentStrategy)...)
 	if len(allErrs) > 0 {
 		return nil, newInvalidErr(new, allErrs)
 	}

--- a/api/v1alpha1/workerdeployment_webhook_test.go
+++ b/api/v1alpha1/workerdeployment_webhook_test.go
@@ -12,10 +12,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	temporaliov1alpha1 "github.com/temporalio/temporal-worker-controller/api/v1alpha1"
+	"github.com/temporalio/temporal-worker-controller/internal/defaults"
 	"github.com/temporalio/temporal-worker-controller/internal/testhelpers"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
@@ -49,6 +52,40 @@ func TestWorkerDeployment_ValidateCreate(t *testing.T) {
 				return obj
 			}),
 			errorMsg: "[spec.rollout.steps[2].rampPercentage: Invalid value: 9: rampPercentage must increase between each step, spec.rollout.steps[4].rampPercentage: Invalid value: 50: rampPercentage must increase between each step]",
+		},
+		"invalid deployment strategy type": {
+			obj: testhelpers.ModifyObj(testhelpers.MakeWDWithName("bad-deployment-strategy-type", ""), func(obj *temporaliov1alpha1.WorkerDeployment) *temporaliov1alpha1.WorkerDeployment {
+				obj.Spec.DeploymentStrategy = &appsv1.DeploymentStrategy{Type: "Bogus"}
+				return obj
+			}),
+			errorMsg: `spec.deploymentStrategy.type: Unsupported value: "Bogus"`,
+		},
+		"recreate with rollingUpdate forbidden": {
+			obj: testhelpers.ModifyObj(testhelpers.MakeWDWithName("recreate-with-rolling-update", ""), func(obj *temporaliov1alpha1.WorkerDeployment) *temporaliov1alpha1.WorkerDeployment {
+				zero := intstr.FromInt32(0)
+				obj.Spec.DeploymentStrategy = &appsv1.DeploymentStrategy{
+					Type: appsv1.RecreateDeploymentStrategyType,
+					RollingUpdate: &appsv1.RollingUpdateDeployment{
+						MaxUnavailable: &zero,
+					},
+				}
+				return obj
+			}),
+			errorMsg: "spec.deploymentStrategy.rollingUpdate: Forbidden",
+		},
+		"maxUnavailable and maxSurge both zero": {
+			obj: testhelpers.ModifyObj(testhelpers.MakeWDWithName("both-zero-surge", ""), func(obj *temporaliov1alpha1.WorkerDeployment) *temporaliov1alpha1.WorkerDeployment {
+				zero := intstr.FromInt32(0)
+				obj.Spec.DeploymentStrategy = &appsv1.DeploymentStrategy{
+					Type: appsv1.RollingUpdateDeploymentStrategyType,
+					RollingUpdate: &appsv1.RollingUpdateDeployment{
+						MaxUnavailable: &zero,
+						MaxSurge:       &zero,
+					},
+				}
+				return obj
+			}),
+			errorMsg: "maxUnavailable and maxSurge cannot both be 0",
 		},
 	}
 
@@ -137,6 +174,31 @@ func TestWorkerDeployment_Default(t *testing.T) {
 				assert.Equal(t, time.Hour, obj.Spec.SunsetStrategy.ScaledownDelay.Duration)
 				require.NotNil(t, obj.Spec.SunsetStrategy.DeleteDelay)
 				assert.Equal(t, 24*time.Hour, obj.Spec.SunsetStrategy.DeleteDelay.Duration)
+			},
+		},
+		"leaves nil deploymentStrategy unset": {
+			obj: testhelpers.MakeWDWithName("nil-deployment-strategy", ""),
+			expected: func(t *testing.T, obj *temporaliov1alpha1.WorkerDeployment) {
+				assert.Nil(t, obj.Spec.DeploymentStrategy)
+			},
+		},
+		"defaults partial deploymentStrategy": {
+			obj: testhelpers.ModifyObj(testhelpers.MakeWDWithName("partial-deployment-strategy", ""), func(obj *temporaliov1alpha1.WorkerDeployment) *temporaliov1alpha1.WorkerDeployment {
+				maxUnavailable := intstr.FromString("5%")
+				obj.Spec.DeploymentStrategy = &appsv1.DeploymentStrategy{
+					RollingUpdate: &appsv1.RollingUpdateDeployment{
+						MaxUnavailable: &maxUnavailable,
+					},
+				}
+				return obj
+			}),
+			expected: func(t *testing.T, obj *temporaliov1alpha1.WorkerDeployment) {
+				require.NotNil(t, obj.Spec.DeploymentStrategy)
+				assert.Equal(t, appsv1.RollingUpdateDeploymentStrategyType, obj.Spec.DeploymentStrategy.Type)
+				require.NotNil(t, obj.Spec.DeploymentStrategy.RollingUpdate)
+				assert.Equal(t, intstr.FromString("5%"), *obj.Spec.DeploymentStrategy.RollingUpdate.MaxUnavailable)
+				require.NotNil(t, obj.Spec.DeploymentStrategy.RollingUpdate.MaxSurge)
+				assert.Equal(t, intstr.FromString(defaults.DeploymentMaxSurge), *obj.Spec.DeploymentStrategy.RollingUpdate.MaxSurge)
 			},
 		},
 	}

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -5,6 +5,7 @@
 package v1alpha1
 
 import (
+	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -776,6 +777,11 @@ func (in *WorkerDeploymentSpec) DeepCopyInto(out *WorkerDeploymentSpec) {
 		in, out := &in.ProgressDeadlineSeconds, &out.ProgressDeadlineSeconds
 		*out = new(int32)
 		**out = **in
+	}
+	if in.DeploymentStrategy != nil {
+		in, out := &in.DeploymentStrategy, &out.DeploymentStrategy
+		*out = new(appsv1.DeploymentStrategy)
+		(*in).DeepCopyInto(*out)
 	}
 	in.RolloutStrategy.DeepCopyInto(&out.RolloutStrategy)
 	in.SunsetStrategy.DeepCopyInto(&out.SunsetStrategy)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -348,6 +348,32 @@ Gate workflow input details:
 
 ## Advanced Configuration
 
+### Deployment Rolling Update Strategy
+
+Controls how Pods are replaced **within a single versioned Kubernetes `Deployment`**. It does **not** affect Temporal traffic routing across worker versions (`spec.rollout.strategy`), and it does **not** apply when the controller creates a new version.
+
+By default the controller derives a new build ID from the pod template. A new build ID creates a **new** Deployment object, so pod replacement for that rollout is just scaling up the new Deployment (and later scaling down/deleting the old one). In that common path, `deploymentStrategy` has no effect.
+
+`deploymentStrategy` matters only when pods roll on an **existing** version Deployment, for example:
+
+- You run `kubectl rollout restart` (or equivalent) against a specific versioned Deployment.
+- You set `spec.workerOptions.unsafeCustomBuildID` and change the pod template without changing that build ID — the controller updates that version's Deployment in place, which triggers a Kubernetes rolling update of its pods.
+- Connection-related fields change and the controller patches the existing Deployment's pod template (env vars / volumes), which also rolls pods in place.
+
+When omitted, Kubernetes defaults apply (`RollingUpdate` with `maxUnavailable`/`maxSurge` of `25%`). On large fleets, set a more conservative strategy if you rely on in-place restarts of Current workers:
+
+```yaml
+spec:
+  replicas: 100
+  deploymentStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 5%
+      maxSurge: 0
+  rollout:
+    strategy: Progressive
+```
+
 ### Environment-Specific Configurations
 
 **Production Configuration:**

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -350,15 +350,7 @@ Gate workflow input details:
 
 ### Deployment Rolling Update Strategy
 
-Controls how Pods are replaced **within a single versioned Kubernetes `Deployment`**. It does **not** affect Temporal traffic routing across worker versions (`spec.rollout.strategy`), and it does **not** apply when the controller creates a new version.
-
-By default the controller derives a new build ID from the pod template. A new build ID creates a **new** Deployment object, so pod replacement for that rollout is just scaling up the new Deployment (and later scaling down/deleting the old one). In that common path, `deploymentStrategy` has no effect.
-
-`deploymentStrategy` matters only when pods roll on an **existing** version Deployment, for example:
-
-- You run `kubectl rollout restart` (or equivalent) against a specific versioned Deployment.
-- You set `spec.workerOptions.unsafeCustomBuildID` and change the pod template without changing that build ID — the controller updates that version's Deployment in place, which triggers a Kubernetes rolling update of its pods.
-- Connection-related fields change and the controller patches the existing Deployment's pod template (env vars / volumes), which also rolls pods in place.
+Controls how Pods are replaced **within a single versioned Kubernetes `Deployment`** via `Deployment.spec.strategy`. It does **not** affect Temporal traffic routing across worker versions (see [Rollout Strategies](#rollout-strategies)).
 
 When omitted, Kubernetes defaults apply (`RollingUpdate` with `maxUnavailable`/`maxSurge` of `25%`). On large fleets, set a more conservative strategy if you rely on in-place restarts of Current workers:
 

--- a/helm/temporal-worker-controller-crds/templates/temporal.io_workerdeployments.yaml
+++ b/helm/temporal-worker-controller-crds/templates/temporal.io_workerdeployments.yaml
@@ -132,6 +132,24 @@ spec:
                     set
                   rule: '!has(self.gate) || !has(self.gate.inputFrom) || (has(self.gate.inputFrom.configMapKeyRef)
                     != has(self.gate.inputFrom.secretKeyRef))'
+              deploymentStrategy:
+                properties:
+                  rollingUpdate:
+                    properties:
+                      maxSurge:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        x-kubernetes-int-or-string: true
+                      maxUnavailable:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  type:
+                    type: string
+                type: object
               sunset:
                 properties:
                   deleteDelay:

--- a/internal/defaults/defaults.go
+++ b/internal/defaults/defaults.go
@@ -13,6 +13,11 @@ const (
 	ServerMaxVersions                = 100
 	MaxVersionsIneligibleForDeletion = int32(ServerMaxVersions * 0.75)
 
+	// DeploymentMaxUnavailable / DeploymentMaxSurge match the apps/v1 Deployment
+	// API defaults for RollingUpdate strategy fields.
+	DeploymentMaxUnavailable = "25%"
+	DeploymentMaxSurge       = "25%"
+
 	// DeprecatedDefaultControllerIdentity is no longer used, except to detect deployments previously
 	// managed by this identity for clean reclamation with the new identity format.
 	DeprecatedDefaultControllerIdentity = "temporal-worker-controller"

--- a/internal/k8s/deployments.go
+++ b/internal/k8s/deployments.go
@@ -302,8 +302,29 @@ func NewDeploymentWithOwnerRef(
 				Spec: *podSpec,
 			},
 			MinReadySeconds: spec.MinReadySeconds,
+			Strategy:        DesiredDeploymentStrategy(spec),
 		},
 	}
+}
+
+// DesiredDeploymentStrategy returns the Deployment strategy to apply from the
+// WorkerDeployment spec. When spec.DeploymentStrategy is nil, returns the zero
+// value so Kubernetes defaults apply. When set, unset subfields are filled with
+// the same defaults the Deployment API server uses so create/update/reconcile
+// stay stable. Defensive against webhook-disabled installs where CR defaulting
+// may not have run.
+func DesiredDeploymentStrategy(spec *temporaliov1alpha1.WorkerDeploymentSpec) appsv1.DeploymentStrategy {
+	if spec == nil || spec.DeploymentStrategy == nil {
+		return appsv1.DeploymentStrategy{}
+	}
+	return *temporaliov1alpha1.DefaultDeploymentStrategy(spec.DeploymentStrategy)
+}
+
+// ApplyDeploymentStrategyDefaults fills Deployment strategy fields the same way
+// the apps/v1 Deployment defaulter does, so comparisons against live objects do
+// not flap on omitted Type / maxUnavailable / maxSurge. The input is not mutated.
+func ApplyDeploymentStrategyDefaults(s appsv1.DeploymentStrategy) appsv1.DeploymentStrategy {
+	return *temporaliov1alpha1.DefaultDeploymentStrategy(&s)
 }
 
 // TODO (Shivam): Change hash when secret name is updated as well.

--- a/internal/k8s/deployments_test.go
+++ b/internal/k8s/deployments_test.go
@@ -31,6 +31,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -592,6 +593,66 @@ func TestNewDeploymentWithOwnerRef_Labels(t *testing.T) {
 
 	assert.Equal(t, "test-worker", deployment.Labels[k8s.WorkerDeploymentNameLabel])
 	assert.Equal(t, "build123", deployment.Labels[k8s.BuildIDLabel])
+}
+
+func TestNewDeploymentWithOwnerRef_Strategy(t *testing.T) {
+	t.Run("omitted strategy leaves zero value for Kubernetes defaults", func(t *testing.T) {
+		deployment := k8s.NewDeploymentWithOwnerRef(
+			&metav1.TypeMeta{},
+			&metav1.ObjectMeta{Name: "test-worker", Namespace: "default"},
+			&temporaliov1alpha1.WorkerDeploymentSpec{},
+			"test-deployment",
+			"build123",
+			temporaliov1alpha1.ConnectionSpec{},
+		)
+
+		assert.Equal(t, appsv1.DeploymentStrategy{}, deployment.Spec.Strategy)
+	})
+
+	t.Run("applies rollingUpdate strategy with defaults filled in", func(t *testing.T) {
+		maxUnavailable := intstr.FromString("5%")
+		maxSurge := intstr.FromInt32(0)
+		deployment := k8s.NewDeploymentWithOwnerRef(
+			&metav1.TypeMeta{},
+			&metav1.ObjectMeta{Name: "test-worker", Namespace: "default"},
+			&temporaliov1alpha1.WorkerDeploymentSpec{
+				DeploymentStrategy: &appsv1.DeploymentStrategy{
+					RollingUpdate: &appsv1.RollingUpdateDeployment{
+						MaxUnavailable: &maxUnavailable,
+						MaxSurge:       &maxSurge,
+					},
+				},
+			},
+			"test-deployment",
+			"build123",
+			temporaliov1alpha1.ConnectionSpec{},
+		)
+
+		assert.Equal(t, appsv1.RollingUpdateDeploymentStrategyType, deployment.Spec.Strategy.Type)
+		require.NotNil(t, deployment.Spec.Strategy.RollingUpdate)
+		assert.Equal(t, maxUnavailable, *deployment.Spec.Strategy.RollingUpdate.MaxUnavailable)
+		assert.Equal(t, maxSurge, *deployment.Spec.Strategy.RollingUpdate.MaxSurge)
+	})
+}
+
+func TestApplyDeploymentStrategyDefaults(t *testing.T) {
+	maxUnavailable := intstr.FromString("5%")
+	originalRollingUpdate := &appsv1.RollingUpdateDeployment{
+		MaxUnavailable: &maxUnavailable,
+	}
+	original := appsv1.DeploymentStrategy{RollingUpdate: originalRollingUpdate}
+
+	got := k8s.ApplyDeploymentStrategyDefaults(original)
+
+	assert.Equal(t, appsv1.RollingUpdateDeploymentStrategyType, got.Type)
+	require.NotNil(t, got.RollingUpdate)
+	assert.Equal(t, maxUnavailable, *got.RollingUpdate.MaxUnavailable)
+	require.NotNil(t, got.RollingUpdate.MaxSurge)
+	assert.Equal(t, intstr.FromString("25%"), *got.RollingUpdate.MaxSurge)
+
+	// Defaulting must not mutate the input (RollingUpdate is a shared pointer).
+	assert.Nil(t, originalRollingUpdate.MaxSurge)
+	assert.Nil(t, original.RollingUpdate.MaxSurge)
 }
 
 func TestComputeConnectionSpecHash(t *testing.T) {

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -18,6 +18,7 @@ import (
 	"github.com/temporalio/temporal-worker-controller/internal/temporal"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
@@ -650,6 +651,36 @@ func updateDeploymentWithPodTemplateSpec(
 		deployment.Spec.Replicas = spec.Replicas
 	}
 	deployment.Spec.MinReadySeconds = spec.MinReadySeconds
+	if spec.DeploymentStrategy != nil {
+		deployment.Spec.Strategy = k8s.DesiredDeploymentStrategy(spec)
+	}
+}
+
+// checkAndUpdateDeploymentStrategy updates an owned Deployment when its rolling
+// update strategy differs from the WorkerDeployment spec. When
+// spec.DeploymentStrategy is nil the controller does not manage strategy and
+// leaves the live Deployment alone.
+func checkAndUpdateDeploymentStrategy(
+	buildID string,
+	k8sState *k8s.DeploymentState,
+	spec *temporaliov1alpha1.WorkerDeploymentSpec,
+) *appsv1.Deployment {
+	if spec.DeploymentStrategy == nil {
+		return nil
+	}
+	existingDeployment, exists := k8sState.Deployments[buildID]
+	if !exists {
+		return nil
+	}
+
+	desired := k8s.DesiredDeploymentStrategy(spec)
+	actual := k8s.ApplyDeploymentStrategyDefaults(existingDeployment.Spec.Strategy)
+	if apiequality.Semantic.DeepEqual(desired, actual) {
+		return nil
+	}
+
+	existingDeployment.Spec.Strategy = desired
+	return existingDeployment
 }
 
 func getUpdateDeployments(
@@ -688,7 +719,43 @@ func getUpdateDeployments(
 		}
 	}
 
+	// Sync Deployment rolling-update strategy on all owned versions. Do this after
+	// the pod-template / connection checks so a deployment already queued for update
+	// also picks up strategy changes in the same write.
+	for _, buildID := range ownedBuildIDs(status) {
+		if updatedBuildIDs[buildID] {
+			if deployment, exists := k8sState.Deployments[buildID]; exists && spec.DeploymentStrategy != nil {
+				deployment.Spec.Strategy = k8s.DesiredDeploymentStrategy(spec)
+			}
+			continue
+		}
+		if deployment := checkAndUpdateDeploymentStrategy(buildID, k8sState, spec); deployment != nil {
+			updateDeployments = append(updateDeployments, deployment)
+			updatedBuildIDs[buildID] = true
+		}
+	}
+
 	return updateDeployments
+}
+
+func ownedBuildIDs(status *temporaliov1alpha1.WorkerDeploymentStatus) []string {
+	var buildIDs []string
+	seen := make(map[string]bool)
+	add := func(buildID string) {
+		if buildID == "" || seen[buildID] {
+			return
+		}
+		seen[buildID] = true
+		buildIDs = append(buildIDs, buildID)
+	}
+	add(status.TargetVersion.BuildID)
+	if status.CurrentVersion != nil {
+		add(status.CurrentVersion.BuildID)
+	}
+	for _, version := range status.DeprecatedVersions {
+		add(version.BuildID)
+	}
+	return buildIDs
 }
 
 // getDeleteDeployments determines which deployments should be deleted

--- a/internal/planner/planner_test.go
+++ b/internal/planner/planner_test.go
@@ -25,6 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 func TestGeneratePlan(t *testing.T) {
@@ -1167,6 +1168,98 @@ func TestUpdateDeploymentWithPodTemplateSpec_ReplicasNilPreserved(t *testing.T) 
 	updateDeploymentWithPodTemplateSpec(dep, spec, temporaliov1alpha1.ConnectionSpec{})
 	require.NotNil(t, dep.Spec.Replicas)
 	assert.Equal(t, int32(5), *dep.Spec.Replicas, "replicas must be preserved when spec.Replicas is nil")
+}
+
+func TestUpdateDeploymentWithPodTemplateSpec_StrategyApplied(t *testing.T) {
+	maxUnavailable := intstr.FromString("5%")
+	maxSurge := intstr.FromInt32(0)
+	dep := &appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{}},
+		},
+	}
+	spec := &temporaliov1alpha1.WorkerDeploymentSpec{
+		DeploymentStrategy: &appsv1.DeploymentStrategy{
+			RollingUpdate: &appsv1.RollingUpdateDeployment{
+				MaxUnavailable: &maxUnavailable,
+				MaxSurge:       &maxSurge,
+			},
+		},
+	}
+	updateDeploymentWithPodTemplateSpec(dep, spec, temporaliov1alpha1.ConnectionSpec{})
+	assert.Equal(t, appsv1.RollingUpdateDeploymentStrategyType, dep.Spec.Strategy.Type)
+	require.NotNil(t, dep.Spec.Strategy.RollingUpdate)
+	assert.Equal(t, maxUnavailable, *dep.Spec.Strategy.RollingUpdate.MaxUnavailable)
+	assert.Equal(t, maxSurge, *dep.Spec.Strategy.RollingUpdate.MaxSurge)
+}
+
+func TestGetUpdateDeployments_StrategyReconcile(t *testing.T) {
+	maxUnavailable := intstr.FromString("5%")
+	maxSurge := intstr.FromInt32(0)
+	desiredStrategy := &appsv1.DeploymentStrategy{
+		RollingUpdate: &appsv1.RollingUpdateDeployment{
+			MaxUnavailable: &maxUnavailable,
+			MaxSurge:       &maxSurge,
+		},
+	}
+
+	currentDefault := intstr.FromString("25%")
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "worker-v1"},
+		Spec: appsv1.DeploymentSpec{
+			Strategy: appsv1.DeploymentStrategy{
+				Type: appsv1.RollingUpdateDeploymentStrategyType,
+				RollingUpdate: &appsv1.RollingUpdateDeployment{
+					MaxUnavailable: &currentDefault,
+					MaxSurge:       &currentDefault,
+				},
+			},
+		},
+	}
+
+	status := &temporaliov1alpha1.WorkerDeploymentStatus{
+		TargetVersion: temporaliov1alpha1.TargetWorkerDeploymentVersion{
+			BaseWorkerDeploymentVersion: temporaliov1alpha1.BaseWorkerDeploymentVersion{BuildID: "v1"},
+		},
+		CurrentVersion: &temporaliov1alpha1.CurrentWorkerDeploymentVersion{
+			BaseWorkerDeploymentVersion: temporaliov1alpha1.BaseWorkerDeploymentVersion{BuildID: "v1"},
+		},
+	}
+	k8sState := &k8s.DeploymentState{
+		Deployments: map[string]*appsv1.Deployment{"v1": deployment},
+	}
+
+	t.Run("updates when strategy differs", func(t *testing.T) {
+		spec := &temporaliov1alpha1.WorkerDeploymentSpec{DeploymentStrategy: desiredStrategy}
+		updates := getUpdateDeployments(k8sState, status, spec, temporaliov1alpha1.ConnectionSpec{})
+		require.Len(t, updates, 1)
+		assert.Equal(t, appsv1.RollingUpdateDeploymentStrategyType, updates[0].Spec.Strategy.Type)
+		require.NotNil(t, updates[0].Spec.Strategy.RollingUpdate)
+		assert.Equal(t, maxUnavailable, *updates[0].Spec.Strategy.RollingUpdate.MaxUnavailable)
+		assert.Equal(t, maxSurge, *updates[0].Spec.Strategy.RollingUpdate.MaxSurge)
+	})
+
+	t.Run("no update when strategy matches after defaults", func(t *testing.T) {
+		deployment.Spec.Strategy = k8s.DesiredDeploymentStrategy(&temporaliov1alpha1.WorkerDeploymentSpec{
+			DeploymentStrategy: desiredStrategy,
+		})
+		spec := &temporaliov1alpha1.WorkerDeploymentSpec{DeploymentStrategy: desiredStrategy}
+		updates := getUpdateDeployments(k8sState, status, spec, temporaliov1alpha1.ConnectionSpec{})
+		assert.Empty(t, updates)
+	})
+
+	t.Run("nil strategy does not manage deployment strategy", func(t *testing.T) {
+		deployment.Spec.Strategy = appsv1.DeploymentStrategy{
+			Type: appsv1.RollingUpdateDeploymentStrategyType,
+			RollingUpdate: &appsv1.RollingUpdateDeployment{
+				MaxUnavailable: &currentDefault,
+				MaxSurge:       &currentDefault,
+			},
+		}
+		updates := getUpdateDeployments(k8sState, status, &temporaliov1alpha1.WorkerDeploymentSpec{}, temporaliov1alpha1.ConnectionSpec{})
+		assert.Empty(t, updates)
+		assert.Equal(t, currentDefault, *deployment.Spec.Strategy.RollingUpdate.MaxUnavailable)
+	})
 }
 
 func TestShouldCreateDeployment(t *testing.T) {


### PR DESCRIPTION
## What

Adds an optional `spec.deploymentStrategy` field on `WorkerDeployment` that mirrors `apps/v1` `Deployment.spec.strategy`. The controller sets it on owned versioned Deployments on create/update and reconciles drift so settings like `maxUnavailable` / `maxSurge` stick.

This is distinct from `spec.rollout.strategy`, which controls Temporal traffic routing across versions.

RollingUpdate settings mainly matter for in-place pod rolls on an existing version Deployment (for example `kubectl rollout restart`, or a pod-template change while `unsafeCustomBuildID` stays the same). The common new-build-ID path creates a fresh Deployment scaled up from zero, so those settings have little practical effect there even though the field is still written onto the object.

## Why

Owned Deployments currently inherit the Kubernetes default rolling update (`25%` / `25%`). On large fleets, in-place restarts of a Current version (same build ID) can take too many pollers offline at once and spike `schedule_to_start`. Users need a conservative strategy such as `maxUnavailable: 5%`.

## Testing

- `make generate manifests`
- `go test ./internal/k8s/ ./internal/planner/ -run 'Strategy|ApplyDeploymentStrategyDefaults|ReplicasNilPreserved'`

Resolves #496