### PR TITLE
fix: make 'make test-unit' work out of the box

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,8 @@ LOCALBIN ?= $(shell pwd)/bin
 $(LOCALBIN):
 	mkdir -p $(LOCALBIN)
 STAMPDIR := .stamp
-export PATH := $(ROOT)/$(LOCALBIN):$(PATH)
-GOINSTALL := GOBIN=$(ROOT)/$(LOCALBIN) go install
+export PATH := $(LOCALBIN):$(PATH)
+GOINSTALL := GOBIN=$(LOCALBIN) go install
 
 OTEL ?= false
 ifeq ($(OTEL),true)
@@ -220,11 +220,11 @@ start-temporal-server: ## Start an ephemeral Temporal server with versioning API
 		--dynamic-config-value system.enableDeploymentVersions=true
 
 .PHONY: test-all
-test-all: manifests generate envtest ## Run tests.
+test-all: manifests generate envtest helm-dependency-build ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test -tags test_dep ./... -coverprofile cover.out
 
 .PHONY: test-unit
-test-unit: envtest ## Run unit tests and webhook integration tests (requires envtest binaries).
+test-unit: envtest helm-dependency-build ## Run unit tests and webhook integration tests (requires envtest binaries and a rendered-chart-capable helm).
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./... -coverprofile cover.out
 
 .PHONY: test-integration
@@ -302,11 +302,27 @@ $(HELM): $(LOCALBIN)
 		echo "$(LOCALBIN)/helm version is not expected $(HELM_VERSION). Removing it before installing."; \
 		rm -rf $(LOCALBIN)/helm; \
 	fi
-	test -s $(LOCALBIN)/helm || curl -fsSL -o get_helm.sh \
+	test -s $(LOCALBIN)/helm || { curl -fsSL -o get_helm.sh \
                                 https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 \
                                 && chmod 700 get_helm.sh \
-                                && GOBIN=$(LOCALBIN) GO111MODULE=on DESIRED_VERSION=$(HELM_VERSION) ./get_helm.sh \
-                                && rm get_helm.sh
+                                && HELM_INSTALL_DIR=$(LOCALBIN) USE_SUDO=false DESIRED_VERSION=$(HELM_VERSION) ./get_helm.sh --no-sudo \
+                                && rm get_helm.sh; }
+
+# The main chart declares a cert-manager subchart dependency (see Chart.lock), which
+# `helm template` — and therefore the webhook envtest suite run by test-unit — needs
+# fetched into helm/temporal-worker-controller/charts. The stamp is keyed to Chart.lock
+# so dependency changes rebuild, while repeat runs stay offline no-ops. Helm repository
+# config/cache are isolated under $(LOCALBIN) so this never reads or modifies the
+# developer's own helm configuration.
+HELM_MAIN_CHART := helm/temporal-worker-controller
+HELM_ISOLATED_ENV := HELM_REPOSITORY_CONFIG=$(LOCALBIN)/helm-repositories.yaml HELM_REPOSITORY_CACHE=$(LOCALBIN)/helm-repository-cache
+
+.PHONY: helm-dependency-build
+helm-dependency-build: $(STAMPDIR)/helm-deps ## Fetch helm chart dependencies needed to render the main chart.
+$(STAMPDIR)/helm-deps: $(HELM_MAIN_CHART)/Chart.lock | $(STAMPDIR) $(HELM)
+	$(HELM_ISOLATED_ENV) $(HELM) repo add jetstack https://charts.jetstack.io --force-update
+	$(HELM_ISOLATED_ENV) $(HELM) dependency build $(HELM_MAIN_CHART) --skip-refresh
+	@touch $@
 
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary. If wrong version is installed, it will be overwritten.

--- a/api/v1alpha1/webhook_suite_test.go
+++ b/api/v1alpha1/webhook_suite_test.go
@@ -167,8 +167,15 @@ var _ = BeforeSuite(func() {
 // This makes the test authoritative against the Helm chart rather than a hand-maintained copy.
 func loadWebhookFromHelmChart(chartPath, webhookName string, extraArgs ...string) *admissionregistrationv1.ValidatingWebhookConfiguration {
 	args := append([]string{"template", "test", chartPath, "--show-only", "templates/webhook.yaml"}, extraArgs...)
-	out, err := exec.Command("helm", args...).Output()
-	Expect(err).NotTo(HaveOccurred(), "helm template failed — is helm installed?")
+	helmBin := os.Getenv("HELM")
+	if helmBin == "" {
+		helmBin = "helm"
+	}
+	out, err := exec.Command(helmBin, args...).Output()
+	Expect(err).NotTo(HaveOccurred(),
+		"helm template failed — is helm installed and the chart's dependencies built? "+
+			"Run via 'make test-unit' (which provisions ./bin/helm and the chart deps), "+
+			"or set HELM to a helm binary path.")
 
 	// The file contains multiple YAML documents; find the requested ValidatingWebhookConfiguration.
 	for _, doc := range bytes.Split(out, []byte("\n---\n")) {

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -40,11 +40,19 @@ func TestControllers(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
+	if os.Getenv("KUBEBUILDER_ASSETS") == "" {
+		Skip("Skipping controller envtest suite: KUBEBUILDER_ASSETS not set")
+	}
+
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
+		CRDDirectoryPaths: []string{
+			// CRDs live in the crds chart's templates directory; there is no
+			// config/crd/bases in this repo.
+			filepath.Join("..", "..", "helm", "temporal-worker-controller-crds", "templates"),
+		},
 		ErrorIfCRDPathMissing: true,
 	}
 


### PR DESCRIPTION
Closes #364.

This fixes `make test-unit` on a fresh checkout by:
- installing and exposing the repository-managed Helm binary
- fetching chart dependencies with an isolated Helm cache
- loading controller envtest CRDs from their actual chart path

Tested with `make test-unit`, including a repeat offline run.