### PR TITLE
feat(helm): support extra manager environment variables

### DIFF
--- a/.github/workflows/helm-validate.yml
+++ b/.github/workflows/helm-validate.yml
@@ -57,6 +57,15 @@ jobs:
             --set kubeRBACProxy.image.tag=test \
             --set kubeRBACProxy.image.pullPolicy=Always
 
+      - name: Template with extra manager environment variables
+        run: |
+          helm template test-release helm/temporal-worker-controller \
+            --set-string extraEnv[0].name=HTTP_PROXY \
+            --set-string extraEnv[0].value=http://proxy.example.com:8080 \
+            --set-string extraEnv[1].name=API_TOKEN \
+            --set-string extraEnv[1].valueFrom.secretKeyRef.name=controller-secrets \
+            --set-string extraEnv[1].valueFrom.secretKeyRef.key=api-token
+
       - name: Template with restricted watch namespaces
         run: |
           helm template test-release helm/temporal-worker-controller \

--- a/helm/temporal-worker-controller/templates/manager.yaml
+++ b/helm/temporal-worker-controller/templates/manager.yaml
@@ -107,6 +107,9 @@ spec:
         - name: WATCH_NAMESPACES
           value: {{ join "," . | quote }}
         {{- end }}
+        {{- with .Values.extraEnv }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         args:
         - --leader-elect
         {{- if .Values.metrics.enabled }}

--- a/helm/temporal-worker-controller/values.schema.json
+++ b/helm/temporal-worker-controller/values.schema.json
@@ -41,6 +41,32 @@
         }
       }
     },
+    "extraEnv": {
+      "type": "array",
+      "default": [],
+      "description": "Additional Kubernetes EnvVar entries for the manager container",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Environment variable name"
+          },
+          "value": {
+            "type": "string",
+            "description": "Literal environment variable value"
+          },
+          "valueFrom": {
+            "type": "object",
+            "description": "Kubernetes EnvVarSource, such as secretKeyRef or configMapKeyRef"
+          }
+        }
+      }
+    },
     "podAnnotations": {
       "type": "object",
       "description": "Additional pod annotations",

--- a/helm/temporal-worker-controller/values.yaml
+++ b/helm/temporal-worker-controller/values.yaml
@@ -4,6 +4,18 @@ image:
   pullPolicy: IfNotPresent
   pullSecrets: []
 
+# Additional environment variables for the manager container.
+# Example:
+# extraEnv:
+#   - name: HTTP_PROXY
+#     value: http://proxy.example.com:8080
+#   - name: API_TOKEN
+#     valueFrom:
+#       secretKeyRef:
+#         name: controller-secrets
+#         key: api-token
+extraEnv: []
+
 podAnnotations: {}
   # Additional pod annotations can be added here
 # example:


### PR DESCRIPTION
## What was changed

Adds a root-level `extraEnv` value to the controller Helm chart. Entries are appended to the manager container environment and support both literal values and Kubernetes `valueFrom` sources. The chart schema requires each entry to have a non-empty name, and the existing Helm validation workflow now renders literal and secret-backed examples.

The empty default preserves the current rendered manifests byte-for-byte.

## Why?

Clusters behind corporate proxies need to pass `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` to the controller. Without a chart value, operators must fork or patch the Deployment even though the Go and gRPC clients already honor those standard environment variables.

## Checklist

1. Closes #510

2. How was this tested:

   - `make test-unit`
   - `make lint-actions`
   - `helm lint --strict helm/temporal-worker-controller`
   - every existing controller/CRD Helm validation render
   - custom render with `HTTP_PROXY`, `NO_PROXY`, and secret-backed `API_TOKEN`, parsed to assert the exact manager env values
   - invalid `extraEnv` entry without `name` is rejected by the chart schema
   - default rendered manifest is byte-identical to `origin/main`
   - `git diff --check`

3. Any docs updates needed?

   No external documentation update is needed. `values.yaml` includes literal and secret-backed examples, and `values.schema.json` documents and validates the supported shape.