### PR TITLE
docs(concepts): warn that changing connectionRef mutates all managed

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -97,14 +97,14 @@ Configuration for the controller's Temporal connection and worker-version identi
 
 Note that the logical Temporal deployment name is not configurable: the controller always derives it from the Kubernetes namespace and `WorkerDeployment` name (see [TEMPORAL_DEPLOYMENT_NAME](#temporal_deployment_name)).
 
-**Warning — changing `connectionRef` affects all managed versions.**
-- A change to `connectionRef` does not create a new version.
-- The controller applies the new `Connection` to every version it manages,
-- including Draining versions that are still serving open pinned workflows.
-- Any retained version whose pod template is not compatible with the new `Connection` will fail to connect and crash loop.
-- Before changing `connectionRef`, ensure every retained version's pod template is compatible with the new `Connection`,
-- For example, if switching from mTLS to an API key, every retained version's worker image must be able to authenticate with the new auth method.
-- Treat a `connectionRef` change as affecting live, draining workloads — not as a forward-only operation.
+**How `connectionRef` changes are applied.**
+
+A change to `connectionRef` does not create a new version. The controller applies
+the new `Connection` to the current and target versions only. Deprecated versions
+(Draining and Drained) keep the connection they were created with.
+
+Note: the old `Connection` CR and its referenced Secret must not be deleted while
+any deprecated version still uses them.
 
 ### Rollout Configuration
 Defines how new versions are promoted:

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -97,6 +97,15 @@ Configuration for the controller's Temporal connection and worker-version identi
 
 Note that the logical Temporal deployment name is not configurable: the controller always derives it from the Kubernetes namespace and `WorkerDeployment` name (see [TEMPORAL_DEPLOYMENT_NAME](#temporal_deployment_name)).
 
+**Warning — changing `connectionRef` affects all managed versions.**
+- A change to `connectionRef` does not create a new version.
+- The controller applies the new `Connection` to every version it manages,
+- including Draining versions that are still serving open pinned workflows.
+- Any retained version whose pod template is not compatible with the new `Connection` will fail to connect and crash loop.
+- Before changing `connectionRef`, ensure every retained version's pod template is compatible with the new `Connection`,
+- For example, if switching from mTLS to an API key, every retained version's worker image must be able to authenticate with the new auth method.
+- Treat a `connectionRef` change as affecting live, draining workloads — not as a forward-only operation.
+
 ### Rollout Configuration
 Defines how new versions are promoted:
 - **strategy**: Manual, AllAtOnce, or Progressive


### PR DESCRIPTION

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Added a warning to docs/concepts.md documenting that changing a WorkerDeployment's connectionRef applies to all managed versions for this bug(https://github.com/temporalio/temporal-worker-controller/issues/477?issue=temporalio%7Ctemporal-worker-controller%7C493)
## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
