### PR TITLE
Updated update-changelog.yml to request reviews from the worker-controller team

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -27,6 +27,14 @@ jobs:
   changelog:
     runs-on: ubuntu-latest
     steps:
+
+      - name: Generate a token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 #v3.2.0
+        with:
+          client-id: ${{ vars.CHANGELOG_APP_ID }}
+          private-key: ${{ secrets.CHANGELOG_APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
         with:
@@ -34,12 +42,25 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.repository.default_branch }}
 
+      - name: Resolve bot identity
+        id: bot
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          slug='${{ steps.app-token.outputs.app-slug }}'
+          id=$(gh api "/users/${slug}%5Bbot%5D" --jq '.id')
+          echo "name=${slug}[bot]" >> "$GITHUB_OUTPUT"
+          echo "email=${id}+${slug}[bot]@users.noreply.github.com" >> "$GITHUB_OUTPUT"
+
       - name: Update changelog
-        uses: shazib-summar/automated-changelog-gh@05d6ccc344bc518f859e830a72137fb58616fb71 #v0.2.0
+        uses: shazib-summar/automated-changelog-gh@b0b9e8ba8eadae8d468650d60c00f0da2af157f2 #v0.3.0
         with:
+          token: ${{ steps.app-token.outputs.token }}
           # see inputs at https://github.com/shazib-summar/automated-changelog-gh#inputs
           tag: ${{ github.event.inputs.tag }}
           mode: ${{ github.event.inputs.mode || 'prepend' }}
           pull-request: true
+          commit-user-name: ${{ steps.bot.outputs.name }}
+          commit-user-email: ${{ steps.bot.outputs.email }}
           pr-labels: changelog,docs,automated
-          reviewers: temporalio/worker-controller
+          team-reviewers: temporalio/worker-controller


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Previously in https://github.com/temporalio/temporal-worker-controller/pull/495 we added a the workflow to automate updates to the CHANGELOG.md file. This workflow lacked the ability to request reviews from the team. This commit enables that.

Further note that the app installation must have the following permissions:
- Contents: Read/Write (Repo level)
- Pull Requests: Read/Write (Repo level)
- Members: Read (Org level)

The members read permission is required to resolve and request reviews from the team.

Followup PR for issue #296  

## Why?
Requested in the last PR.

## Checklist
<!--- add/delete as needed --->

2. How was this tested:
Tested in a personal org and repo with a test app installation. Feel free to review
- https://github.com/shazzy-test-org/test-repo/pull/8 and
- https://github.com/shazzy-test-org/test-repo/blob/main/.github/workflows/update-changelog.yml

3. Any docs updates needed?
No.
