### PR TITLE
Fix: pin connection on deprecated versions

### DIFF
--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -519,7 +519,7 @@ func removeTLSVolume(volumes []corev1.Volume) []corev1.Volume {
 func ensureTLSVolumeMount(mounts []corev1.VolumeMount) []corev1.VolumeMount {
 	for i := range mounts {
 		if mounts[i].Name == "temporal-tls" {
-			mounts[i].Name = "/etc/temporal/tls"
+			mounts[i].MountPath = "/etc/temporal/tls"
 			return mounts
 		}
 	}
@@ -685,16 +685,6 @@ func getUpdateDeployments(
 		if deployment := checkAndUpdateDeploymentConnectionSpec(status.CurrentVersion.BuildID, k8sState, connection); deployment != nil {
 			updateDeployments = append(updateDeployments, deployment)
 			updatedBuildIDs[status.CurrentVersion.BuildID] = true
-		}
-	}
-
-	// Check deprecated versions for expired connection spec hashes
-	for _, version := range status.DeprecatedVersions {
-		if !updatedBuildIDs[version.BuildID] {
-			if deployment := checkAndUpdateDeploymentConnectionSpec(version.BuildID, k8sState, connection); deployment != nil {
-				updateDeployments = append(updateDeployments, deployment)
-				updatedBuildIDs[version.BuildID] = true
-			}
 		}
 	}
 

--- a/internal/planner/planner_test.go
+++ b/internal/planner/planner_test.go
@@ -361,7 +361,101 @@ func TestGeneratePlan(t *testing.T) {
 			config: &Config{
 				RolloutStrategy: temporaliov1alpha1.RolloutStrategy{},
 			},
-			expectUpdate: 1,
+			expectUpdate: 0,
+		},
+		{
+			name: "connection change updates target and current but not deprecated (pinned)",
+			k8sState: &k8s.DeploymentState{
+				Deployments: map[string]*appsv1.Deployment{
+					"123": createDeploymentWithExpiredConnectionSpecHash(1),
+					"456": createDeploymentWithExpiredConnectionSpecHash(1),
+					"789": createDeploymentWithExpiredConnectionSpecHash(1),
+				},
+			},
+			status: &temporaliov1alpha1.WorkerDeploymentStatus{
+				TargetVersion: temporaliov1alpha1.TargetWorkerDeploymentVersion{
+					BaseWorkerDeploymentVersion: temporaliov1alpha1.BaseWorkerDeploymentVersion{
+						BuildID:    "123",
+						Status:     temporaliov1alpha1.VersionStatusRamping,
+						Deployment: &corev1.ObjectReference{Name: "test-123"},
+					},
+				},
+				CurrentVersion: &temporaliov1alpha1.CurrentWorkerDeploymentVersion{
+					BaseWorkerDeploymentVersion: temporaliov1alpha1.BaseWorkerDeploymentVersion{
+						BuildID:    "456",
+						Status:     temporaliov1alpha1.VersionStatusCurrent,
+						Deployment: &corev1.ObjectReference{Name: "test-456"},
+					},
+				},
+				DeprecatedVersions: []*temporaliov1alpha1.DeprecatedWorkerDeploymentVersion{
+					{
+						BaseWorkerDeploymentVersion: temporaliov1alpha1.BaseWorkerDeploymentVersion{
+							BuildID:    "789",
+							Status:     temporaliov1alpha1.VersionStatusDraining,
+							Deployment: &corev1.ObjectReference{Name: "test-789"},
+						},
+					},
+				},
+			},
+			spec: &temporaliov1alpha1.WorkerDeploymentSpec{
+				Replicas: func() *int32 { r := int32(1); return &r }(),
+			},
+			state: &temporal.TemporalWorkerState{},
+			config: &Config{
+				RolloutStrategy: temporaliov1alpha1.RolloutStrategy{},
+			},
+			expectUpdate: 2,
+		},
+		{
+			name: "multiple deprecated versions with expired hashes are all pinned",
+			k8sState: &k8s.DeploymentState{
+				Deployments: map[string]*appsv1.Deployment{
+					"123": createDeploymentWithDefaultConnectionSpecHash(1),
+					"456": createDeploymentWithDefaultConnectionSpecHash(1),
+					"789": createDeploymentWithExpiredConnectionSpecHash(1),
+					"101": createDeploymentWithExpiredConnectionSpecHash(1),
+				},
+			},
+			status: &temporaliov1alpha1.WorkerDeploymentStatus{
+				TargetVersion: temporaliov1alpha1.TargetWorkerDeploymentVersion{
+					BaseWorkerDeploymentVersion: temporaliov1alpha1.BaseWorkerDeploymentVersion{
+						BuildID:    "123",
+						Status:     temporaliov1alpha1.VersionStatusRamping,
+						Deployment: &corev1.ObjectReference{Name: "test-123"},
+					},
+				},
+				CurrentVersion: &temporaliov1alpha1.CurrentWorkerDeploymentVersion{
+					BaseWorkerDeploymentVersion: temporaliov1alpha1.BaseWorkerDeploymentVersion{
+						BuildID:    "456",
+						Status:     temporaliov1alpha1.VersionStatusCurrent,
+						Deployment: &corev1.ObjectReference{Name: "test-456"},
+					},
+				},
+				DeprecatedVersions: []*temporaliov1alpha1.DeprecatedWorkerDeploymentVersion{
+					{
+						BaseWorkerDeploymentVersion: temporaliov1alpha1.BaseWorkerDeploymentVersion{
+							BuildID:    "789",
+							Status:     temporaliov1alpha1.VersionStatusDraining,
+							Deployment: &corev1.ObjectReference{Name: "test-789"},
+						},
+					},
+					{
+						BaseWorkerDeploymentVersion: temporaliov1alpha1.BaseWorkerDeploymentVersion{
+							BuildID:    "101",
+							Status:     temporaliov1alpha1.VersionStatusDrained,
+							Deployment: &corev1.ObjectReference{Name: "test-101"},
+						},
+					},
+				},
+			},
+			spec: &temporaliov1alpha1.WorkerDeploymentSpec{
+				Replicas: func() *int32 { r := int32(1); return &r }(),
+			},
+			state: &temporal.TemporalWorkerState{},
+			config: &Config{
+				RolloutStrategy: temporaliov1alpha1.RolloutStrategy{},
+			},
+			expectUpdate: 0,
 		},
 		{
 			name: "update deployment when current version has an expired connection spec hash",


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

In `internal/planner/planner.go` there's a `getUpdateDeployments` function that gets called during the planning process and looks at the observed state and returns a list of of existing Deployments that need their pod/connection updated.
Currently there's a loop that propagates connectionRef changes to draining and drained versions.
I deleted that loop so that only target and current versions now follow connectionRef changes. Deprecated versions(draining and drained) keep the connection baked into their Deployment at creation time.

During end to end testing I ran into a Kubernetes validation error(`volumeMounts[0].name: Not found: "/etc/temporal/tls")` from my previous pr(https://github.com/temporalio/temporal-worker-controller/pull/516#issuecomment-5258412619), `ensureTLSVolumeMount` was setting `Name` instead of `MountPath` so I addressed that here.
## Why?
<!-- Tell your future self why have you made these changes -->

Context: https://github.com/temporalio/temporal-worker-controller/issues/493
When switching `ConnectionRef` switching connectionRef on their WorkerDeployments. The controller re-pointed all versions(current,draining and drained) at the new connection. Draining versions had working credentials and were serving open pinned workflows so they should have been left untouched.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

Unit tests
Local end 2 end (Kind cluster + Temporal Cloud)
I reproduced the bug and verified the fix with a 3 version rainbow deployment (v1 DRAINING, v2 DRAINING, v3 CURRENT) connected to ns-nm-twc-01.temporal-dev namespace over mTLS.

Before the fix: I changed mutualTLSSecretRef from temporal-cloud-mtls to temporal-cloud-mtls-2. All three versions updated:
<img width="1066" height="233" alt="Screenshot 2026-08-12 at 12 59 57 PM" src="https://github.com/user-attachments/assets/9745c994-3fa7-48ce-8461-b012a9ae0416" />

After the fix: I made the same connection change. Only v3 (current version) updated; v1 and v2 (draining) stayed pinned
<img width="1179" height="173" alt="image" src="https://github.com/user-attachments/assets/fce51d56-897f-4dc8-b8c7-7da287e857bd" />

Auth switch of mTLS to API key was not testable in local staging due to environment constraint. I got a `certificate signed by unknown authority` and similar errors I mentioned in https://github.com/temporalio/temporal-worker-controller/issues/493

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
