### PR TITLE
Fix: Skip replica management when HPA is attached

### DIFF
--- a/internal/controller/execplan.go
+++ b/internal/controller/execplan.go
@@ -94,7 +94,7 @@ func (r *WorkerDeploymentReconciler) executeK8sOperations(ctx context.Context, l
 
 	// Scale deployments
 	for d, replicas := range p.ScaleDeployments {
-		l.Info("scaling deployment", "deployment", d, "replicas", replicas)
+		l.Info("scaling deployment", "deploymentName", d.Name, "deploymentNamespace", d.Namespace, "replicas", replicas)
 		dep := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
 			Namespace:       d.Namespace,
 			Name:            d.Name,

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -157,8 +157,8 @@ func GeneratePlan(
 
 	// Add delete/scale operations based on version status
 	plan.DeleteDeployments = getDeleteDeployments(k8sState, status, spec, foundDeploymentInTemporal)
-	hpaBuildIDs := hpaBuildIDSet(wrts, k8sState)
-	plan.ScaleDeployments = getScaleDeployments(l, k8sState, status, spec, hpaBuildIDs)
+	hpaManaged := hasHPAScaler(wrts)
+	plan.ScaleDeployments = getScaleDeployments(l, k8sState, status, spec, hpaManaged)
 	plan.ShouldCreateDeployment = shouldCreateDeployment(status, maxVersionsIneligibleForDeletion)
 	plan.UpdateDeployments = getUpdateDeployments(k8sState, status, spec, connection)
 
@@ -736,18 +736,9 @@ func getDeleteDeployments(
 	return deleteDeployments
 }
 
-// hpaBuildIDSet returns a set of build IDs whose versions are managed by a
-// HorizontalPodAutoscaler through a WorkerResourceTemplate. When a version's build ID is in
-// this set, the controller must not manage that version's replica count, the HPA manages the scaling.
-//
-// A WRT renders one copy of its resource per active build ID (a build ID with a live Deployment in
-// k8sState), so an HPA-kind WRT marks every currently-active build ID.
-func hpaBuildIDSet(wrts []temporaliov1alpha1.WorkerResourceTemplate, k8sState *k8s.DeploymentState) map[string]bool {
-	hpaBuildIDs := make(map[string]bool)
-	if k8sState == nil {
-		return hpaBuildIDs
-	}
-
+// hasHPAScaler checks whether any WorkerResourceTemplate attaches a HorizontalPodAutoscaler to
+// this WorkerDeployment.When an HPA— the HPA manages the scaling not the Controller.
+func hasHPAScaler(wrts []temporaliov1alpha1.WorkerResourceTemplate) bool {
 	for i := range wrts {
 		// Parse kind from the WRT's spec.template
 		var templateMeta struct {
@@ -758,16 +749,11 @@ func hpaBuildIDSet(wrts []temporaliov1alpha1.WorkerResourceTemplate, k8sState *k
 		if err := json.Unmarshal(wrts[i].Spec.Template.Raw, &templateMeta); err != nil {
 			continue
 		}
-		if templateMeta.Kind != "HorizontalPodAutoscaler" {
-			continue
-		}
-
-		// This WRT is an HPA: it manages current active version's scaling
-		for buildID := range k8sState.Deployments {
-			hpaBuildIDs[buildID] = true
+		if templateMeta.Kind == "HorizontalPodAutoscaler" {
+			return true
 		}
 	}
-	return hpaBuildIDs
+	return false
 }
 
 // getScaleDeployments determines which deployments should be explicitly scaled and to what size.
@@ -778,7 +764,7 @@ func getScaleDeployments(
 	k8sState *k8s.DeploymentState,
 	status *temporaliov1alpha1.WorkerDeploymentStatus,
 	spec *temporaliov1alpha1.WorkerDeploymentSpec,
-	hpaBuildIDs map[string]bool,
+	hpaManaged bool,
 ) map[*corev1.ObjectReference]uint32 {
 	scaleDeployments := make(map[*corev1.ObjectReference]uint32)
 
@@ -786,10 +772,9 @@ func getScaleDeployments(
 	if status.CurrentVersion != nil && status.CurrentVersion.Deployment != nil {
 
 		// HPA exists — skip, don't touch replicas
-		if hpaBuildIDs[status.CurrentVersion.BuildID] {
+		if hpaManaged {
 			if spec.Replicas != nil {
-				l.Info("WorkerDeployment spec.Replicas is set but an HPA is managing this version's scaling; ignoring spec.Replicas",
-					"buildID", status.CurrentVersion.BuildID)
+				l.Info("HPA is managing this WorkerDeployment's scaling; ignoring spec.Replicas")
 			}
 		} else if spec.Replicas != nil {
 			// If spec.Replicas is non-nil, the controller is managing replicas instead of a scaler resource.
@@ -811,14 +796,12 @@ func getScaleDeployments(
 		status.TargetVersion.Deployment != nil {
 		if d, exists := k8sState.Deployments[status.TargetVersion.BuildID]; exists {
 
-			hasHPA := hpaBuildIDs[status.TargetVersion.BuildID]
-			if hasHPA && spec.Replicas != nil {
-				l.Info("WorkerDeployment spec.Replicas is set but an HPA is managing this version's scaling; ignoring spec.Replicas",
-					"buildID", status.TargetVersion.BuildID)
+			if hpaManaged && spec.Replicas != nil {
+				l.Info("HPA is managing this WorkerDeployment's scaling; ignoring spec.Replicas")
 			}
 
 			// Enforce spec.Replicas only when NO HPA manages this version — otherwise the HPA owns it.
-			enforceReplicas := spec.Replicas != nil && !hasHPA
+			enforceReplicas := spec.Replicas != nil && !hpaManaged
 			// Bootstrap 0 -> 1 regardless of HPA: an HPA cannot scale a Deployment up from zero, so if the
 			// Target Version was scaled to zero by Sunset Policy and nil replicas means a scaler owns it,
 			// the controller must bring it back to 1 for the HPA to take over.

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -157,7 +157,8 @@ func GeneratePlan(
 
 	// Add delete/scale operations based on version status
 	plan.DeleteDeployments = getDeleteDeployments(k8sState, status, spec, foundDeploymentInTemporal)
-	plan.ScaleDeployments = getScaleDeployments(k8sState, status, spec)
+	hpaBuildIDs := hpaBuildIDSet(wrts, k8sState)
+	plan.ScaleDeployments = getScaleDeployments(l, k8sState, status, spec, hpaBuildIDs)
 	plan.ShouldCreateDeployment = shouldCreateDeployment(status, maxVersionsIneligibleForDeletion)
 	plan.UpdateDeployments = getUpdateDeployments(k8sState, status, spec, connection)
 
@@ -735,21 +736,64 @@ func getDeleteDeployments(
 	return deleteDeployments
 }
 
+// hpaBuildIDSet returns a set of build IDs whose versions are managed by a
+// HorizontalPodAutoscaler through a WorkerResourceTemplate. When a version's build ID is in
+// this set, the controller must not manage that version's replica count, the HPA manages the scaling.
+//
+// A WRT renders one copy of its resource per active build ID (a build ID with a live Deployment in
+// k8sState), so an HPA-kind WRT marks every currently-active build ID.
+func hpaBuildIDSet(wrts []temporaliov1alpha1.WorkerResourceTemplate, k8sState *k8s.DeploymentState) map[string]bool {
+	hpaBuildIDs := make(map[string]bool)
+	if k8sState == nil {
+		return hpaBuildIDs
+	}
+
+	for i := range wrts {
+		// Parse kind from the WRT's spec.template
+		var templateMeta struct {
+			Kind string `json:"kind"`
+		}
+
+		// skip if template is unparseable
+		if err := json.Unmarshal(wrts[i].Spec.Template.Raw, &templateMeta); err != nil {
+			continue
+		}
+		if templateMeta.Kind != "HorizontalPodAutoscaler" {
+			continue
+		}
+
+		// This WRT is an HPA: it manages current active version's scaling
+		for buildID := range k8sState.Deployments {
+			hpaBuildIDs[buildID] = true
+		}
+	}
+	return hpaBuildIDs
+}
+
 // getScaleDeployments determines which deployments should be explicitly scaled and to what size.
 // It only runs when spec.Replicas is set (controller-managed mode). Drained versions and inactive
 // versions that are not the rollout target are always scaled to zero during sunset.
 func getScaleDeployments(
+	l logr.Logger,
 	k8sState *k8s.DeploymentState,
 	status *temporaliov1alpha1.WorkerDeploymentStatus,
 	spec *temporaliov1alpha1.WorkerDeploymentSpec,
+	hpaBuildIDs map[string]bool,
 ) map[*corev1.ObjectReference]uint32 {
 	scaleDeployments := make(map[*corev1.ObjectReference]uint32)
 
 	// Scale the current version if needed
 	if status.CurrentVersion != nil && status.CurrentVersion.Deployment != nil {
-		// If spec.Replicas is non-nil, the controller is managing replicas instead of a scaler resource.
-		// Scale the Current Version per the WorkerDeploymentSpec.Replicas value.
-		if spec.Replicas != nil {
+
+		// HPA exists — skip, don't touch replicas
+		if hpaBuildIDs[status.CurrentVersion.BuildID] {
+			if spec.Replicas != nil {
+				l.Info("WorkerDeployment spec.Replicas is set but an HPA is managing this version's scaling; ignoring spec.Replicas",
+					"buildID", status.CurrentVersion.BuildID)
+			}
+		} else if spec.Replicas != nil {
+			// If spec.Replicas is non-nil, the controller is managing replicas instead of a scaler resource.
+			// Scale the Current Version per the WorkerDeploymentSpec.Replicas value.
 			replicas := *spec.Replicas
 			ref := status.CurrentVersion.Deployment
 			if d, exists := k8sState.Deployments[status.CurrentVersion.BuildID]; exists {
@@ -757,7 +801,9 @@ func getScaleDeployments(
 					scaleDeployments[ref] = uint32(replicas)
 				}
 			}
+
 		}
+
 	}
 
 	// Scale the target version if it exists, and isn't current
@@ -765,12 +811,21 @@ func getScaleDeployments(
 		status.TargetVersion.Deployment != nil {
 		if d, exists := k8sState.Deployments[status.TargetVersion.BuildID]; exists {
 
-			// If the Target Version is an already-existing Deployment that was scaled to zero by the controller
-			// due to Sunset Policy, and the TWD has nil replicas because a scaler is managing the replicas, then
-			// no one will scale the Target Version back up, so we need to scale it back to 1 replica, which is what
-			// would happen if the Deployment was being created from scratch with nil replicas.
-			if spec.Replicas != nil || (spec.Replicas == nil && d.Spec.Replicas != nil && *d.Spec.Replicas == 0) {
-				replicas := int32(1) // just scale up to 1 if we are in the spec.Replicas == nil && d.Spec.Replicas == 0 case.
+			hasHPA := hpaBuildIDs[status.TargetVersion.BuildID]
+			if hasHPA && spec.Replicas != nil {
+				l.Info("WorkerDeployment spec.Replicas is set but an HPA is managing this version's scaling; ignoring spec.Replicas",
+					"buildID", status.TargetVersion.BuildID)
+			}
+
+			// Enforce spec.Replicas only when NO HPA manages this version — otherwise the HPA owns it.
+			enforceReplicas := spec.Replicas != nil && !hasHPA
+			// Bootstrap 0 -> 1 regardless of HPA: an HPA cannot scale a Deployment up from zero, so if the
+			// Target Version was scaled to zero by Sunset Policy and nil replicas means a scaler owns it,
+			// the controller must bring it back to 1 for the HPA to take over.
+			bootstrapFromZero := spec.Replicas == nil && d.Spec.Replicas != nil && *d.Spec.Replicas == 0
+
+			if enforceReplicas || bootstrapFromZero {
+				replicas := int32(1) // just scale up to 1 in the bootstrapFromZero case.
 				if spec.Replicas != nil {
 					replicas = *spec.Replicas
 				}

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -737,7 +737,7 @@ func getDeleteDeployments(
 }
 
 // hasHPAScaler checks whether any WorkerResourceTemplate attaches a HorizontalPodAutoscaler to
-// this WorkerDeployment.When an HPA— the HPA manages the scaling not the Controller.
+// this WorkerDeployment.When an HPA exists, the HPA manages the scaling not the Controller.
 func hasHPAScaler(wrts []temporaliov1alpha1.WorkerResourceTemplate) bool {
 	for i := range wrts {
 		// Parse kind from the WRT's spec.template

--- a/internal/planner/planner_test.go
+++ b/internal/planner/planner_test.go
@@ -840,7 +840,7 @@ func TestGetScaleDeployments(t *testing.T) {
 		status      *temporaliov1alpha1.WorkerDeploymentStatus
 		spec        *temporaliov1alpha1.WorkerDeploymentSpec
 		state       *temporal.TemporalWorkerState
-		hpaBuildIDs map[string]bool
+		hpaManaged  bool
 		// map of build id to scaled replicas
 		expectScales map[string]uint32
 	}{
@@ -1156,7 +1156,7 @@ func TestGetScaleDeployments(t *testing.T) {
 			spec: &temporaliov1alpha1.WorkerDeploymentSpec{
 				Replicas: func() *int32 { r := int32(1); return &r }(),
 			},
-			hpaBuildIDs: map[string]bool{"cur": true},
+			hpaManaged: true,
 			// controller defers to HPA, does not reset to spec.Replicas
 			expectScales: map[string]uint32{},
 		},
@@ -1187,7 +1187,7 @@ func TestGetScaleDeployments(t *testing.T) {
 				Replicas: func() *int32 { r := int32(1); return &r }(),
 			},
 			// no HPA
-			hpaBuildIDs: nil,
+			hpaManaged: false,
 			// controller enforces spec.Replicas
 			expectScales: map[string]uint32{"test-cur": 1},
 		},
@@ -1211,7 +1211,7 @@ func TestGetScaleDeployments(t *testing.T) {
 			spec: &temporaliov1alpha1.WorkerDeploymentSpec{
 				Replicas: func() *int32 { r := int32(1); return &r }(),
 			},
-			hpaBuildIDs: map[string]bool{"tgt": true},
+			hpaManaged: true,
 			// HPA owns replicas; enforcement skipped
 			expectScales: map[string]uint32{},
 		},
@@ -1232,7 +1232,7 @@ func TestGetScaleDeployments(t *testing.T) {
 				},
 			},
 			spec:         &temporaliov1alpha1.WorkerDeploymentSpec{}, // Replicas nil
-			hpaBuildIDs:  map[string]bool{"tgt": true},
+			hpaManaged:   true,
 			expectScales: map[string]uint32{"test-tgt": 1},
 		},
 		{
@@ -1268,7 +1268,7 @@ func TestGetScaleDeployments(t *testing.T) {
 				},
 				Replicas: func() *int32 { r := int32(1); return &r }(),
 			},
-			hpaBuildIDs:  map[string]bool{"drn": true},
+			hpaManaged:   true,
 			expectScales: map[string]uint32{"test-drn": 0}, // sunset scale to zero ignores HPA presence
 		},
 		{
@@ -1305,14 +1305,14 @@ func TestGetScaleDeployments(t *testing.T) {
 				},
 			},
 			spec:         &temporaliov1alpha1.WorkerDeploymentSpec{}, // Replicas nil
-			hpaBuildIDs:  nil,
+			hpaManaged:   false,
 			expectScales: map[string]uint32{}, // draining versions are left untouched
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			scales := getScaleDeployments(logr.Discard(), tc.k8sState, tc.status, tc.spec, tc.hpaBuildIDs)
+			scales := getScaleDeployments(logr.Discard(), tc.k8sState, tc.status, tc.spec, tc.hpaManaged)
 			assert.Equal(t, len(tc.expectScales), len(scales), "unexpected number of scales")
 			actualScaleDeploymentNames := make([]string, 0)
 			for deploymentRef, actualReplicas := range scales {
@@ -1330,7 +1330,7 @@ func TestGetScaleDeployments(t *testing.T) {
 	}
 }
 
-func TestHPABuildIDSet(t *testing.T) {
+func TestHasHPAScaler(t *testing.T) {
 	hpaWRT := temporaliov1alpha1.WorkerResourceTemplate{
 		Spec: temporaliov1alpha1.WorkerResourceTemplateSpec{
 			Template: runtime.RawExtension{
@@ -1345,21 +1345,13 @@ func TestHPABuildIDSet(t *testing.T) {
 			},
 		},
 	}
-	k8sState := &k8s.DeploymentState{
-		Deployments: map[string]*appsv1.Deployment{
-			"abc": createDeploymentWithDefaultConnectionSpecHash(1),
-			"def": createDeploymentWithDefaultConnectionSpecHash(1),
-		},
-	}
 
-	t.Run("HPA-kind WRT marks all active build IDs", func(t *testing.T) {
-		got := hpaBuildIDSet([]temporaliov1alpha1.WorkerResourceTemplate{hpaWRT, pdbWRT}, k8sState)
-		assert.Equal(t, map[string]bool{"abc": true, "def": true}, got)
+	t.Run("HPA-kind WRT is detected", func(t *testing.T) {
+		assert.True(t, hasHPAScaler([]temporaliov1alpha1.WorkerResourceTemplate{hpaWRT, pdbWRT}))
 	})
 
-	t.Run("PDB-only WRT marks nothing", func(t *testing.T) {
-		got := hpaBuildIDSet([]temporaliov1alpha1.WorkerResourceTemplate{pdbWRT}, k8sState)
-		assert.Empty(t, got)
+	t.Run("PDB-only WRT is not an HPA", func(t *testing.T) {
+		assert.False(t, hasHPAScaler([]temporaliov1alpha1.WorkerResourceTemplate{pdbWRT}))
 	})
 }
 

--- a/internal/planner/planner_test.go
+++ b/internal/planner/planner_test.go
@@ -519,7 +519,7 @@ func TestGeneratePlan(t *testing.T) {
 			wrts: []temporaliov1alpha1.WorkerResourceTemplate{
 				createTestWRT("my-hpa", "my-worker"),
 			},
-			expectScale:                 1,
+			expectScale:                 0,
 			expectWorkerResourceApplies: 2,
 		},
 		{
@@ -835,11 +835,12 @@ func TestGetDeleteDeployments(t *testing.T) {
 
 func TestGetScaleDeployments(t *testing.T) {
 	testCases := []struct {
-		name     string
-		k8sState *k8s.DeploymentState
-		status   *temporaliov1alpha1.WorkerDeploymentStatus
-		spec     *temporaliov1alpha1.WorkerDeploymentSpec
-		state    *temporal.TemporalWorkerState
+		name        string
+		k8sState    *k8s.DeploymentState
+		status      *temporaliov1alpha1.WorkerDeploymentStatus
+		spec        *temporaliov1alpha1.WorkerDeploymentSpec
+		state       *temporal.TemporalWorkerState
+		hpaBuildIDs map[string]bool
 		// map of build id to scaled replicas
 		expectScales map[string]uint32
 	}{
@@ -1129,11 +1130,189 @@ func TestGetScaleDeployments(t *testing.T) {
 			},
 			expectScales: map[string]uint32{}, // No scaling yet because not enough time passed
 		},
+		{
+			name: "current version with HPA and spec.Replicas set is not scaled",
+			k8sState: &k8s.DeploymentState{
+				Deployments: map[string]*appsv1.Deployment{
+					"cur": createDeploymentWithDefaultConnectionSpecHash(3),
+				},
+			},
+			status: &temporaliov1alpha1.WorkerDeploymentStatus{
+				TargetVersion: temporaliov1alpha1.TargetWorkerDeploymentVersion{
+					BaseWorkerDeploymentVersion: temporaliov1alpha1.BaseWorkerDeploymentVersion{
+						BuildID:    "cur",
+						Status:     temporaliov1alpha1.VersionStatusCurrent,
+						Deployment: &corev1.ObjectReference{Name: "test-cur"},
+					},
+				},
+				CurrentVersion: &temporaliov1alpha1.CurrentWorkerDeploymentVersion{
+					BaseWorkerDeploymentVersion: temporaliov1alpha1.BaseWorkerDeploymentVersion{
+						BuildID:    "cur",
+						Status:     temporaliov1alpha1.VersionStatusCurrent,
+						Deployment: &corev1.ObjectReference{Name: "test-cur"},
+					},
+				},
+			},
+			spec: &temporaliov1alpha1.WorkerDeploymentSpec{
+				Replicas: func() *int32 { r := int32(1); return &r }(),
+			},
+			hpaBuildIDs: map[string]bool{"cur": true},
+			// controller defers to HPA, does not reset to spec.Replicas
+			expectScales: map[string]uint32{},
+		},
+		{
+			name: "current version without HPA and spec.Replicas set is scaled",
+			k8sState: &k8s.DeploymentState{
+				Deployments: map[string]*appsv1.Deployment{
+					"cur": createDeploymentWithDefaultConnectionSpecHash(3),
+				},
+			},
+			status: &temporaliov1alpha1.WorkerDeploymentStatus{
+				TargetVersion: temporaliov1alpha1.TargetWorkerDeploymentVersion{
+					BaseWorkerDeploymentVersion: temporaliov1alpha1.BaseWorkerDeploymentVersion{
+						BuildID:    "cur",
+						Status:     temporaliov1alpha1.VersionStatusCurrent,
+						Deployment: &corev1.ObjectReference{Name: "test-cur"},
+					},
+				},
+				CurrentVersion: &temporaliov1alpha1.CurrentWorkerDeploymentVersion{
+					BaseWorkerDeploymentVersion: temporaliov1alpha1.BaseWorkerDeploymentVersion{
+						BuildID:    "cur",
+						Status:     temporaliov1alpha1.VersionStatusCurrent,
+						Deployment: &corev1.ObjectReference{Name: "test-cur"},
+					},
+				},
+			},
+			spec: &temporaliov1alpha1.WorkerDeploymentSpec{
+				Replicas: func() *int32 { r := int32(1); return &r }(),
+			},
+			// no HPA
+			hpaBuildIDs: nil,
+			// controller enforces spec.Replicas
+			expectScales: map[string]uint32{"test-cur": 1},
+		},
+		{
+			name: "target version with HPA and spec.Replicas set is not scaled",
+			k8sState: &k8s.DeploymentState{
+				Deployments: map[string]*appsv1.Deployment{
+					"tgt": createDeploymentWithDefaultConnectionSpecHash(3), // HPA scaled this up
+				},
+			},
+			status: &temporaliov1alpha1.WorkerDeploymentStatus{
+				TargetVersion: temporaliov1alpha1.TargetWorkerDeploymentVersion{
+					BaseWorkerDeploymentVersion: temporaliov1alpha1.BaseWorkerDeploymentVersion{
+						BuildID:    "tgt",
+						Status:     temporaliov1alpha1.VersionStatusRamping,
+						Deployment: &corev1.ObjectReference{Name: "test-tgt"},
+					},
+				},
+				// no CurrentVersion, so the target branch runs
+			},
+			spec: &temporaliov1alpha1.WorkerDeploymentSpec{
+				Replicas: func() *int32 { r := int32(1); return &r }(),
+			},
+			hpaBuildIDs: map[string]bool{"tgt": true},
+			// HPA owns replicas; enforcement skipped
+			expectScales: map[string]uint32{},
+		},
+		{
+			name: "target version with HPA and nil replicas and Deployment at 0 is bootstrapped to 1",
+			k8sState: &k8s.DeploymentState{
+				Deployments: map[string]*appsv1.Deployment{
+					"tgt": createDeploymentWithDefaultConnectionSpecHash(0), // scaled to zero by sunset
+				},
+			},
+			status: &temporaliov1alpha1.WorkerDeploymentStatus{
+				TargetVersion: temporaliov1alpha1.TargetWorkerDeploymentVersion{
+					BaseWorkerDeploymentVersion: temporaliov1alpha1.BaseWorkerDeploymentVersion{
+						BuildID:    "tgt",
+						Status:     temporaliov1alpha1.VersionStatusRamping,
+						Deployment: &corev1.ObjectReference{Name: "test-tgt"},
+					},
+				},
+			},
+			spec:         &temporaliov1alpha1.WorkerDeploymentSpec{}, // Replicas nil
+			hpaBuildIDs:  map[string]bool{"tgt": true},
+			expectScales: map[string]uint32{"test-tgt": 1},
+		},
+		{
+			name: "drained version with HPA is still scaled to zero (sunset cleanup unchanged)",
+			k8sState: &k8s.DeploymentState{
+				Deployments: map[string]*appsv1.Deployment{
+					"cur": createDeploymentWithDefaultConnectionSpecHash(1),
+					"drn": createDeploymentWithDefaultConnectionSpecHash(2),
+				},
+			},
+			status: &temporaliov1alpha1.WorkerDeploymentStatus{
+				TargetVersion: temporaliov1alpha1.TargetWorkerDeploymentVersion{
+					BaseWorkerDeploymentVersion: temporaliov1alpha1.BaseWorkerDeploymentVersion{
+						BuildID:    "cur",
+						Status:     temporaliov1alpha1.VersionStatusCurrent,
+						Deployment: &corev1.ObjectReference{Name: "test-cur"},
+					},
+				},
+				DeprecatedVersions: []*temporaliov1alpha1.DeprecatedWorkerDeploymentVersion{
+					{
+						BaseWorkerDeploymentVersion: temporaliov1alpha1.BaseWorkerDeploymentVersion{
+							BuildID:    "drn",
+							Status:     temporaliov1alpha1.VersionStatusDrained,
+							Deployment: &corev1.ObjectReference{Name: "test-drn"},
+						},
+						DrainedSince: &metav1.Time{Time: time.Now().Add(-24 * time.Hour)},
+					},
+				},
+			},
+			spec: &temporaliov1alpha1.WorkerDeploymentSpec{
+				SunsetStrategy: temporaliov1alpha1.SunsetStrategy{
+					ScaledownDelay: &metav1.Duration{Duration: 0},
+				},
+				Replicas: func() *int32 { r := int32(1); return &r }(),
+			},
+			hpaBuildIDs:  map[string]bool{"drn": true},
+			expectScales: map[string]uint32{"test-drn": 0}, // sunset scale to zero ignores HPA presence
+		},
+		{
+			name: "draining version is never in scale set",
+			k8sState: &k8s.DeploymentState{
+				Deployments: map[string]*appsv1.Deployment{
+					"cur":  createDeploymentWithDefaultConnectionSpecHash(1),
+					"drng": createDeploymentWithDefaultConnectionSpecHash(3),
+				},
+			},
+			status: &temporaliov1alpha1.WorkerDeploymentStatus{
+				TargetVersion: temporaliov1alpha1.TargetWorkerDeploymentVersion{
+					BaseWorkerDeploymentVersion: temporaliov1alpha1.BaseWorkerDeploymentVersion{
+						BuildID:    "cur",
+						Status:     temporaliov1alpha1.VersionStatusCurrent,
+						Deployment: &corev1.ObjectReference{Name: "test-cur"},
+					},
+				},
+				CurrentVersion: &temporaliov1alpha1.CurrentWorkerDeploymentVersion{
+					BaseWorkerDeploymentVersion: temporaliov1alpha1.BaseWorkerDeploymentVersion{
+						BuildID:    "cur",
+						Status:     temporaliov1alpha1.VersionStatusCurrent,
+						Deployment: &corev1.ObjectReference{Name: "test-cur"},
+					},
+				},
+				DeprecatedVersions: []*temporaliov1alpha1.DeprecatedWorkerDeploymentVersion{
+					{
+						BaseWorkerDeploymentVersion: temporaliov1alpha1.BaseWorkerDeploymentVersion{
+							BuildID:    "drng",
+							Status:     temporaliov1alpha1.VersionStatusDraining,
+							Deployment: &corev1.ObjectReference{Name: "test-drng"},
+						},
+					},
+				},
+			},
+			spec:         &temporaliov1alpha1.WorkerDeploymentSpec{}, // Replicas nil
+			hpaBuildIDs:  nil,
+			expectScales: map[string]uint32{}, // draining versions are left untouched
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			scales := getScaleDeployments(tc.k8sState, tc.status, tc.spec)
+			scales := getScaleDeployments(logr.Discard(), tc.k8sState, tc.status, tc.spec, tc.hpaBuildIDs)
 			assert.Equal(t, len(tc.expectScales), len(scales), "unexpected number of scales")
 			actualScaleDeploymentNames := make([]string, 0)
 			for deploymentRef, actualReplicas := range scales {
@@ -1149,6 +1328,39 @@ func TestGetScaleDeployments(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestHPABuildIDSet(t *testing.T) {
+	hpaWRT := temporaliov1alpha1.WorkerResourceTemplate{
+		Spec: temporaliov1alpha1.WorkerResourceTemplateSpec{
+			Template: runtime.RawExtension{
+				Raw: []byte(`{"apiVersion":"autoscaling/v2","kind":"HorizontalPodAutoscaler"}`),
+			},
+		},
+	}
+	pdbWRT := temporaliov1alpha1.WorkerResourceTemplate{
+		Spec: temporaliov1alpha1.WorkerResourceTemplateSpec{
+			Template: runtime.RawExtension{
+				Raw: []byte(`{"apiVersion":"policy/v1","kind":"PodDisruptionBudget"}`),
+			},
+		},
+	}
+	k8sState := &k8s.DeploymentState{
+		Deployments: map[string]*appsv1.Deployment{
+			"abc": createDeploymentWithDefaultConnectionSpecHash(1),
+			"def": createDeploymentWithDefaultConnectionSpecHash(1),
+		},
+	}
+
+	t.Run("HPA-kind WRT marks all active build IDs", func(t *testing.T) {
+		got := hpaBuildIDSet([]temporaliov1alpha1.WorkerResourceTemplate{hpaWRT, pdbWRT}, k8sState)
+		assert.Equal(t, map[string]bool{"abc": true, "def": true}, got)
+	})
+
+	t.Run("PDB-only WRT marks nothing", func(t *testing.T) {
+		got := hpaBuildIDSet([]temporaliov1alpha1.WorkerResourceTemplate{pdbWRT}, k8sState)
+		assert.Empty(t, got)
+	})
 }
 
 // TestUpdateDeploymentInPlace_ReplicasNil verifies that updateDeploymentInPlace does not

--- a/internal/planner/planner_test.go
+++ b/internal/planner/planner_test.go
@@ -835,12 +835,12 @@ func TestGetDeleteDeployments(t *testing.T) {
 
 func TestGetScaleDeployments(t *testing.T) {
 	testCases := []struct {
-		name        string
-		k8sState    *k8s.DeploymentState
-		status      *temporaliov1alpha1.WorkerDeploymentStatus
-		spec        *temporaliov1alpha1.WorkerDeploymentSpec
-		state       *temporal.TemporalWorkerState
-		hpaManaged  bool
+		name       string
+		k8sState   *k8s.DeploymentState
+		status     *temporaliov1alpha1.WorkerDeploymentStatus
+		spec       *temporaliov1alpha1.WorkerDeploymentSpec
+		state      *temporal.TemporalWorkerState
+		hpaManaged bool
 		// map of build id to scaled replicas
 		expectScales map[string]uint32
 	}{


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

When an HPA exists via `WorkerResourceTemplate` the controller now skips enforcing the deployment's `spec.Replicas` of that version letting HPA manage the scaling.

## Changes
I added a wew helper function `hpaBuildIDSet()` in planner.go It detects HPA-kind WRTs and marks all active build IDs as HPA managed
I added `hpaBuildIDs` parameter on getScaleDeployments. It skips spec.Replicas enforcement for versions in this set
Target version : gated on `!hasHPA` for `spec.Replicas` enforcement, but preserves the 0 - >1 bootstrap since HPAs cannot scale a Deployment from zero
I added Logs  warning when spec.Replicas is set alongside an HPA, so a developer see the conflicting config instead of a silent fight

## Why?
<!-- Tell your future self why have you made these changes -->
A developer configured a WorkerResourceTemplate with an HPA (minReplicas: 3) on a WorkerDeployment that also had spec.replicas: 1
The controller enforced replicas: 1 every 15 seconds, the HPA scaled back to 3, creating an endless loop
The root cause was `getScaleDeployments` enforced a WD's `spec.Replicas` on every reconcile without checking whether an HPA is already managing that Deployment's replica count.


## Checklist
<!--- add/delete as needed --->

1. Closes #350

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Unit tests
Local e2e test (Kind cluster + Temporal Cloud)
Reproduced the bug and verified the fix on a Kind cluster
Before the fix, when I edited the WorkerDeployment's spec.Replicas to 1, the Controller locked replicas at 1 even thought I had an HPA with a minimum of 3 replicas and max 10. HPA was only used when WorkerDeployment's spec.Replicas was nil.

After this fix: Same spec.replicas: 1. Replicas stayed at 3 (HPA's value).

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
