### PR TITLE
feat(rbac): namespaced webhook auth and a migratable SA-UID identity

### DIFF
--- a/api/v1alpha1/workerresourcetemplate_webhook.go
+++ b/api/v1alpha1/workerresourcetemplate_webhook.go
@@ -11,6 +11,7 @@ import (
 	authorizationv1 "k8s.io/api/authorization/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -164,7 +165,7 @@ func (v *WorkerResourceTemplateValidator) validate(ctx context.Context, oldWRT, 
 		)
 	}
 
-	// API-dependent checks (RESTMapper scope + SubjectAccessReview)
+	// API-dependent checks (RESTMapper scope + LocalSubjectAccessReview)
 	apiWarnings, apiErrs := v.validateWithAPI(ctx, newWRT, verb)
 	warnings = append(warnings, apiWarnings...)
 	allErrs = append(allErrs, apiErrs...)
@@ -462,7 +463,7 @@ func convertUserInfoExtra(extra map[string]authenticationv1.ExtraValue) map[stri
 }
 
 // validateWithAPI performs API-dependent validation: RESTMapper scope check and
-// SubjectAccessReview for both the requesting user and the controller service account.
+// LocalSubjectAccessReview for both the requesting user and the controller service account.
 // verb is the RBAC verb to check ("create" on create/update, "delete" on delete).
 func (v *WorkerResourceTemplateValidator) validateWithAPI(ctx context.Context, wrt *WorkerResourceTemplate, verb string) (admission.Warnings, field.ErrorList) {
 	var allErrs field.ErrorList
@@ -520,10 +521,11 @@ func (v *WorkerResourceTemplateValidator) validateWithAPI(ctx context.Context, w
 		}
 	}
 
-	// 2. SubjectAccessReview: requesting user
+	// 2. LocalSubjectAccessReview: requesting user
 	req, reqErr := admission.RequestFromContext(ctx)
 	if reqErr == nil && req.UserInfo.Username != "" {
-		userSAR := &authorizationv1.SubjectAccessReview{
+		userSAR := &authorizationv1.LocalSubjectAccessReview{
+			ObjectMeta: metav1.ObjectMeta{Namespace: wrt.Namespace},
 			Spec: authorizationv1.SubjectAccessReviewSpec{
 				User:   req.UserInfo.Username,
 				Groups: req.UserInfo.Groups,
@@ -559,7 +561,7 @@ func (v *WorkerResourceTemplateValidator) validateWithAPI(ctx context.Context, w
 		}
 	}
 
-	// 3. SubjectAccessReview: controller service account.
+	// 3. LocalSubjectAccessReview: controller service account.
 	// When Kubernetes evaluates a real request from a service account token, it automatically
 	// considers the SA's username AND the groups the SA belongs to. When we construct a SAR
 	// manually (without a real token), we must supply those groups ourselves — Kubernetes will
@@ -569,7 +571,8 @@ func (v *WorkerResourceTemplateValidator) validateWithAPI(ctx context.Context, w
 	// the groups here mirrors what Kubernetes would do for a real request from the SA.
 	if v.ControllerSAName != "" && v.ControllerSANamespace != "" {
 		controllerUser := fmt.Sprintf("system:serviceaccount:%s:%s", v.ControllerSANamespace, v.ControllerSAName)
-		controllerSAR := &authorizationv1.SubjectAccessReview{
+		controllerSAR := &authorizationv1.LocalSubjectAccessReview{
+			ObjectMeta: metav1.ObjectMeta{Namespace: wrt.Namespace},
 			Spec: authorizationv1.SubjectAccessReviewSpec{
 				User: controllerUser,
 				Groups: []string{

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -192,13 +192,34 @@ func main() {
 		os.Exit(1)
 	}
 
-	var ns corev1.Namespace
-	if err := mgr.GetAPIReader().Get(context.Background(), types.NamespacedName{Name: podNamespace}, &ns); err != nil {
-		setupLog.Error(err, "unable to fetch namespace UID for controller identity suffix")
+	saName := os.Getenv("SERVICE_ACCOUNT_NAME")
+	if saName == "" {
+		setupLog.Error(nil, "SERVICE_ACCOUNT_NAME environment variable must be set")
 		os.Exit(1)
 	}
-	if err := os.Setenv(controller.IdentitySuffixEnvKey, string(ns.UID)); err != nil {
+
+	var sa corev1.ServiceAccount
+	if err := mgr.GetAPIReader().Get(context.Background(), types.NamespacedName{Namespace: podNamespace, Name: saName}, &sa); err != nil {
+		setupLog.Error(err, "unable to fetch service account UID for controller identity suffix")
+		os.Exit(1)
+	}
+	if err := os.Setenv(controller.IdentitySuffixEnvKey, string(sa.UID)); err != nil {
 		setupLog.Error(err, fmt.Sprintf("unable to set %s", controller.IdentitySuffixEnvKey))
+		os.Exit(1)
+	}
+
+	// Migration window: also record the namespace UID as the legacy identity suffix so the
+	// controller can re-claim Worker Deployments still managed under its previous
+	// (namespace-UID) identity instead of deadlocking after this upgrade. This requires the
+	// cluster-scoped namespaces "get" grant; both the read and the grant can be removed in a
+	// future release once all managed deployments have been re-claimed under the SA-UID identity.
+	var ns corev1.Namespace
+	if err := mgr.GetAPIReader().Get(context.Background(), types.NamespacedName{Name: podNamespace}, &ns); err != nil {
+		setupLog.Error(err, "unable to fetch namespace UID for legacy controller identity suffix")
+		os.Exit(1)
+	}
+	if err := os.Setenv(controller.LegacyIdentitySuffixEnvKey, string(ns.UID)); err != nil {
+		setupLog.Error(err, fmt.Sprintf("unable to set %s", controller.LegacyIdentitySuffixEnvKey))
 		os.Exit(1)
 	}
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -195,13 +195,34 @@ func main() {
 		os.Exit(1)
 	}
 
-	var ns corev1.Namespace
-	if err := mgr.GetAPIReader().Get(context.Background(), types.NamespacedName{Name: podNamespace}, &ns); err != nil {
-		setupLog.Error(err, "unable to fetch namespace UID for controller identity suffix")
+	saName := os.Getenv("SERVICE_ACCOUNT_NAME")
+	if saName == "" {
+		setupLog.Error(nil, "SERVICE_ACCOUNT_NAME environment variable must be set")
 		os.Exit(1)
 	}
-	if err := os.Setenv(controller.IdentitySuffixEnvKey, string(ns.UID)); err != nil {
+
+	var sa corev1.ServiceAccount
+	if err := mgr.GetAPIReader().Get(context.Background(), types.NamespacedName{Namespace: podNamespace, Name: saName}, &sa); err != nil {
+		setupLog.Error(err, "unable to fetch service account UID for controller identity suffix")
+		os.Exit(1)
+	}
+	if err := os.Setenv(controller.IdentitySuffixEnvKey, string(sa.UID)); err != nil {
 		setupLog.Error(err, fmt.Sprintf("unable to set %s", controller.IdentitySuffixEnvKey))
+		os.Exit(1)
+	}
+
+	// Migration window: also record the namespace UID as the legacy identity suffix so the
+	// controller can re-claim Worker Deployments still managed under its previous
+	// (namespace-UID) identity instead of deadlocking after this upgrade. This requires the
+	// cluster-scoped namespaces "get" grant; both the read and the grant can be removed in a
+	// future release once all managed deployments have been re-claimed under the SA-UID identity.
+	var ns corev1.Namespace
+	if err := mgr.GetAPIReader().Get(context.Background(), types.NamespacedName{Name: podNamespace}, &ns); err != nil {
+		setupLog.Error(err, "unable to fetch namespace UID for legacy controller identity suffix")
+		os.Exit(1)
+	}
+	if err := os.Setenv(controller.LegacyIdentitySuffixEnvKey, string(ns.UID)); err != nil {
+		setupLog.Error(err, fmt.Sprintf("unable to set %s", controller.LegacyIdentitySuffixEnvKey))
 		os.Exit(1)
 	}
 

--- a/hack/sync-rbac-rules.py
+++ b/hack/sync-rbac-rules.py
@@ -10,8 +10,8 @@ The Helm template contains two marker pairs:
   # GENERATED RULES (NAMESPACED) END      the namespaced Role (restrictWatchNamespaces)
 
 Both are updated from config/rbac/role.yaml.  The namespaced block excludes
-rules for cluster-scoped resources (namespaces, subjectaccessreviews) since
-those are handled by the separate manager-cluster-role.
+rules for cluster-scoped resources (namespaces) since those are handled by
+the separate manager-cluster-role.
 """
 import re
 import sys
@@ -24,7 +24,7 @@ END_MARKER = "  # GENERATED RULES END"
 BEGIN_MARKER_NS = "  # GENERATED RULES (NAMESPACED) BEGIN"
 END_MARKER_NS = "  # GENERATED RULES (NAMESPACED) END"
 
-CLUSTER_SCOPED_RESOURCES = {"namespaces", "subjectaccessreviews"}
+CLUSTER_SCOPED_RESOURCES = {"namespaces"}
 
 
 def extract_rules_text(path):

--- a/hack/sync-rbac-rules.py
+++ b/hack/sync-rbac-rules.py
@@ -10,8 +10,9 @@ The Helm template contains two marker pairs:
   # GENERATED RULES (NAMESPACED) END      the namespaced Role (restrictWatchNamespaces)
 
 Both are updated from config/rbac/role.yaml.  The namespaced block excludes
-rules for cluster-scoped resources (namespaces, subjectaccessreviews) since
-those are handled by the separate manager-cluster-role.
+rules for cluster-scoped resources (namespaces, subjectaccessreviews,
+clusterconnections) since those are handled by the separate
+manager-cluster-role.
 """
 import re
 import sys

--- a/helm/temporal-worker-controller/templates/rbac.yaml
+++ b/helm/temporal-worker-controller/templates/rbac.yaml
@@ -58,10 +58,49 @@ subjects:
     name: {{ .Values.serviceAccount.name | default (printf "%s-service-account" .Release.Name) }}
     namespace: {{ .Release.Namespace }}
 ---
+# The controller reads its own ServiceAccount at startup to derive a stable
+# identity suffix (the SA UID) used to claim Worker Deployment ownership. The
+# ServiceAccount lives in the release namespace, so a namespaced Role suffices in
+# both cluster-wide and namespace-scoped modes.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/component: rbac
+    {{- include "temporal-worker-controller.labels" . | nindent 4 }}
+  name: {{ .Release.Name }}-identity-reader-role
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    resourceNames:
+      - {{ .Values.serviceAccount.name | default (printf "%s-service-account" .Release.Name) }}
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: rbac
+    {{- include "temporal-worker-controller.labels" . | nindent 4 }}
+  name: {{ .Release.Name }}-identity-reader-rolebinding
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Release.Name }}-identity-reader-role
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.serviceAccount.name | default (printf "%s-service-account" .Release.Name) }}
+    namespace: {{ .Release.Namespace }}
+---
 {{- if .Values.rbac.restrictWatchNamespaces }}
 # Namespace-scoped mode: the manager role is emitted as a namespaced Role in each
-# watched namespace. Cluster-scoped rules (namespaces get, subjectaccessreviews
-# create) are handled by the separate manager-cluster-role below.
+# watched namespace. The one cluster-scoped rule (namespaces get) is handled by the
+# separate manager-cluster-role below.
 {{- range .Values.rbac.restrictWatchNamespaces }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -107,6 +146,12 @@ rules:
       - deployments/scale
     verbs:
       - update
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - localsubjectaccessreviews
+    verbs:
+      - create
   - apiGroups:
       - temporal.io
     resources:
@@ -222,7 +267,7 @@ rules:
   - apiGroups:
       - authorization.k8s.io
     resources:
-      - subjectaccessreviews
+      - localsubjectaccessreviews
     verbs:
       - create
   - apiGroups:
@@ -292,11 +337,11 @@ rules:
 {{- end }}
 ---
 {{- if .Values.rbac.restrictWatchNamespaces }}
-# Namespace-scoped mode: the manager role is bound only within the watched
-# namespaces (RoleBindings below). The two grants that must stay cluster-wide are
-# split into a minimal ClusterRole: namespaces "get" (restricted to the release
-# namespace, for the controller identity-suffix lookup) and subjectaccessreviews
-# "create" (the always-on validating webhook).
+# Namespace-scoped mode: the manager role is bound only within the watched namespaces
+# (RoleBindings below). The one grant that must stay cluster-scoped is namespaces "get"
+# (restricted to the release namespace), used to read the namespace UID for the legacy
+# controller identity during the migration window. It is split into a minimal
+# manager-cluster-role and can be removed once the legacy identity is no longer needed.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -313,12 +358,6 @@ rules:
       - {{ .Release.Namespace }}
     verbs:
       - get
-  - apiGroups:
-      - authorization.k8s.io
-    resources:
-      - subjectaccessreviews
-    verbs:
-      - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/helm/temporal-worker-controller/templates/rbac.yaml
+++ b/helm/temporal-worker-controller/templates/rbac.yaml
@@ -58,10 +58,49 @@ subjects:
     name: {{ .Values.serviceAccount.name | default (printf "%s-service-account" .Release.Name) }}
     namespace: {{ .Release.Namespace }}
 ---
+# The controller reads its own ServiceAccount at startup to derive a stable
+# identity suffix (the SA UID) used to claim Worker Deployment ownership. The
+# ServiceAccount lives in the release namespace, so a namespaced Role suffices in
+# both cluster-wide and namespace-scoped modes.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/component: rbac
+    {{- include "temporal-worker-controller.labels" . | nindent 4 }}
+  name: {{ .Release.Name }}-identity-reader-role
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    resourceNames:
+      - {{ .Values.serviceAccount.name | default (printf "%s-service-account" .Release.Name) }}
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: rbac
+    {{- include "temporal-worker-controller.labels" . | nindent 4 }}
+  name: {{ .Release.Name }}-identity-reader-rolebinding
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Release.Name }}-identity-reader-role
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.serviceAccount.name | default (printf "%s-service-account" .Release.Name) }}
+    namespace: {{ .Release.Namespace }}
+---
 {{- if .Values.rbac.restrictWatchNamespaces }}
 # Namespace-scoped mode: the manager role is emitted as a namespaced Role in each
-# watched namespace. Cluster-scoped rules (namespaces get, subjectaccessreviews
-# create) are handled by the separate manager-cluster-role below.
+# watched namespace. The one cluster-scoped rule (namespaces get) is handled by the
+# separate manager-cluster-role below.
 {{- range .Values.rbac.restrictWatchNamespaces }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -107,6 +146,12 @@ rules:
       - deployments/scale
     verbs:
       - update
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - localsubjectaccessreviews
+    verbs:
+      - create
   - apiGroups:
       - temporal.io
     resources:
@@ -222,7 +267,7 @@ rules:
   - apiGroups:
       - authorization.k8s.io
     resources:
-      - subjectaccessreviews
+      - localsubjectaccessreviews
     verbs:
       - create
   - apiGroups:
@@ -294,11 +339,11 @@ rules:
 {{- end }}
 ---
 {{- if .Values.rbac.restrictWatchNamespaces }}
-# Namespace-scoped mode: the manager role is bound only within the watched
-# namespaces (RoleBindings below). The two grants that must stay cluster-wide are
-# split into a minimal ClusterRole: namespaces "get" (restricted to the release
-# namespace, for the controller identity-suffix lookup) and subjectaccessreviews
-# "create" (the always-on validating webhook).
+# Namespace-scoped mode: the manager role is bound only within the watched namespaces
+# (RoleBindings below). The one grant that must stay cluster-scoped is namespaces "get"
+# (restricted to the release namespace), used to read the namespace UID for the legacy
+# controller identity during the migration window. It is split into a minimal
+# manager-cluster-role and can be removed once the legacy identity is no longer needed.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -315,12 +360,6 @@ rules:
       - {{ .Release.Namespace }}
     verbs:
       - get
-  - apiGroups:
-      - authorization.k8s.io
-    resources:
-      - subjectaccessreviews
-    verbs:
-      - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/internal/controller/execplan.go
+++ b/internal/controller/execplan.go
@@ -287,6 +287,12 @@ func (r *WorkerDeploymentReconciler) shouldClaimManagerIdentity(vcfg *planner.Ve
 	if existing == getDeprecatedControllerIdentity() {
 		return true
 	}
+	// Reclaim deployments still claimed under this controller's legacy identity (the
+	// pre-migration namespace-UID suffix) so an identity-suffix change on upgrade adopts
+	// them instead of deadlocking. See getLegacyControllerIdentity.
+	if legacy := getLegacyControllerIdentity(); legacy != "" && existing == legacy {
+		return true
+	}
 	return false
 }
 

--- a/internal/controller/execplan.go
+++ b/internal/controller/execplan.go
@@ -207,6 +207,12 @@ func (r *WorkerDeploymentReconciler) shouldClaimManagerIdentity(vcfg *planner.Ve
 	if existing == getDeprecatedControllerIdentity() {
 		return true
 	}
+	// Reclaim deployments still claimed under this controller's legacy identity (the
+	// pre-migration namespace-UID suffix) so an identity-suffix change on upgrade adopts
+	// them instead of deadlocking. See getLegacyControllerIdentity.
+	if legacy := getLegacyControllerIdentity(); legacy != "" && existing == legacy {
+		return true
+	}
 	return false
 }
 

--- a/internal/controller/util.go
+++ b/internal/controller/util.go
@@ -38,6 +38,7 @@ const (
 	VersionEnvKey                                    = "CONTROLLER_VERSION"
 	IdentityEnvKey                                   = "CONTROLLER_IDENTITY"
 	IdentitySuffixEnvKey                             = "CONTROLLER_IDENTITY_SUFFIX"
+	LegacyIdentitySuffixEnvKey                       = "CONTROLLER_IDENTITY_LEGACY_SUFFIX"
 	MaxDeploymentVersionsIneligibleForDeletionEnvKey = "CONTROLLER_MAX_DEPLOYMENT_VERSIONS_INELIGIBLE_FOR_DELETION"
 
 	serverDeleteVersionIdentity = "try-delete-for-add-version"
@@ -68,13 +69,28 @@ func getDeprecatedControllerIdentity() string {
 	return defaults.DeprecatedDefaultControllerIdentity
 }
 
-// getControllerIdentity returns the identity with controller env var and namespace uid suffix.
+// getControllerIdentity returns the identity with controller env var and service account uid suffix.
 // Presence of both are ensured by main() and in Reconcile() for users of the controller as a library.
 func getControllerIdentity() string {
 	id := os.Getenv(IdentityEnvKey)
 	suffix := os.Getenv(IdentitySuffixEnvKey)
 	if id != "" && suffix != "" {
 		return id + "/" + suffix
+	}
+	return ""
+}
+
+// getLegacyControllerIdentity returns the controller identity formed with the legacy
+// suffix (the pre-migration namespace UID), or "" if no legacy suffix is configured.
+// During the migration window after the identity suffix source changed from the namespace
+// UID to the ServiceAccount UID, a Worker Deployment still claimed under the legacy identity
+// is treated as reclaimable so the controller adopts it under its current identity instead
+// of deadlocking. TODO: remove once all managed deployments have been re-claimed.
+func getLegacyControllerIdentity() string {
+	id := os.Getenv(IdentityEnvKey)
+	legacySuffix := os.Getenv(LegacyIdentitySuffixEnvKey)
+	if id != "" && legacySuffix != "" {
+		return id + "/" + legacySuffix
 	}
 	return ""
 }

--- a/internal/controller/worker_controller.go
+++ b/internal/controller/worker_controller.go
@@ -97,7 +97,7 @@ type WorkerDeploymentReconciler struct {
 // +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
 // +kubebuilder:rbac:groups=temporal.io,resources=workerresourcetemplates,verbs=get;list;watch;patch;update
 // +kubebuilder:rbac:groups=temporal.io,resources=workerresourcetemplates/status,verbs=get;patch;update
-// +kubebuilder:rbac:groups=authorization.k8s.io,resources=subjectaccessreviews,verbs=create
+// +kubebuilder:rbac:groups=authorization.k8s.io,resources=localsubjectaccessreviews,verbs=create
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/internal/controller/worker_controller.go
+++ b/internal/controller/worker_controller.go
@@ -105,7 +105,7 @@ type WorkerDeploymentReconciler struct {
 // +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
 // +kubebuilder:rbac:groups=temporal.io,resources=workerresourcetemplates,verbs=get;list;watch;patch;update
 // +kubebuilder:rbac:groups=temporal.io,resources=workerresourcetemplates/status,verbs=get;patch;update
-// +kubebuilder:rbac:groups=authorization.k8s.io,resources=subjectaccessreviews,verbs=create
+// +kubebuilder:rbac:groups=authorization.k8s.io,resources=localsubjectaccessreviews,verbs=create
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/internal/tests/internal/env_helpers.go
+++ b/internal/tests/internal/env_helpers.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -138,9 +139,15 @@ func setupTestEnvironment(t *testing.T) (*rest.Config, client.Client, manager.Ma
 		t.Fatalf("failed to create k8s client: %v", err)
 	}
 
-	// Create manager
+	// Create manager. SkipNameValidation lets the same reconciler name be registered
+	// across multiple Test functions in one process (controller-runtime otherwise enforces
+	// globally-unique controller names for metrics).
+	skipNameValidation := true
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme.Scheme,
+		Controller: config.Controller{
+			SkipNameValidation: &skipNameValidation,
+		},
 	})
 	if err != nil {
 		t.Fatalf("failed to create manager: %v", err)

--- a/internal/tests/internal/manager_identity_migration_integration_test.go
+++ b/internal/tests/internal/manager_identity_migration_integration_test.go
@@ -1,0 +1,120 @@
+package internal
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	temporaliov1alpha1 "github.com/temporalio/temporal-worker-controller/api/v1alpha1"
+	"github.com/temporalio/temporal-worker-controller/internal/controller"
+	"github.com/temporalio/temporal-worker-controller/internal/k8s"
+	"github.com/temporalio/temporal-worker-controller/internal/testhelpers"
+	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/temporal"
+	"go.temporal.io/server/temporaltest"
+	temporalClient "go.temporal.io/sdk/client"
+)
+
+// simulateIdentitySuffixUpgrade simulates a helm upgrade that changes the controller's
+// identity suffix (the ns-UID -> SA-UID change). It claims the Worker Deployment's manager
+// identity as the controller's pre-upgrade identity (prefix + legacySuffix), then sets the
+// running reconciler's new primary suffix while retaining the previous suffix as the legacy
+// suffix, exactly as the upgraded main() does.
+func simulateIdentitySuffixUpgrade(legacySuffix, newSuffix string) func(t *testing.T, ctx context.Context, tc testhelpers.TestCase, env testhelpers.TestEnv) {
+	return func(t *testing.T, ctx context.Context, tc testhelpers.TestCase, env testhelpers.TestEnv) {
+		legacyIdentity := testControllerIdentityPrefix + "/" + legacySuffix
+		workerDeploymentName := k8s.ComputeWorkerDeploymentName(tc.GetTWD())
+		c, err := temporalClient.Dial(temporalClient.Options{
+			HostPort:  env.Ts.GetFrontendHostPort(),
+			Namespace: env.Ts.GetDefaultNamespace(),
+			Identity:  legacyIdentity,
+		})
+		if err != nil {
+			t.Fatalf("failed to dial temporal with identity %q: %v", legacyIdentity, err)
+		}
+		defer c.Close()
+
+		if _, err := c.WorkerDeploymentClient().GetHandle(workerDeploymentName).SetManagerIdentity(ctx,
+			temporalClient.WorkerDeploymentSetManagerIdentityOptions{Self: true}); err != nil {
+			t.Fatalf("failed to claim manager identity %q: %v", legacyIdentity, err)
+		}
+		t.Logf("claimed manager identity as pre-upgrade identity %q", legacyIdentity)
+
+		// Upgraded controller: new SA-UID primary suffix, previous ns-UID suffix retained as
+		// the legacy suffix so the deployment can be re-claimed instead of deadlocking.
+		t.Setenv(controller.IdentitySuffixEnvKey, newSuffix)
+		t.Setenv(controller.LegacyIdentitySuffixEnvKey, legacySuffix)
+		t.Logf("upgraded identity suffix %q -> %q (legacy suffix retained)", legacySuffix, newSuffix)
+	}
+}
+
+// TestManagerIdentitySuffixMigration exercises a helm upgrade that changes the controller
+// identity suffix, as the namespace-UID -> ServiceAccount-UID change does.
+//
+// A Worker Deployment already managed under the pre-upgrade identity should remain
+// manageable after the suffix changes: the controller must be able to promote a new
+// version. Without a migration path the controller does not re-claim the deployment and
+// Temporal blocks routing changes from the new identity, so v1 is never promoted to
+// current (the manager-identity deadlock raised in review).
+//
+// This test asserts the desired post-migration behaviour: after the suffix change the
+// controller re-claims the deployment under its new identity and promotes v1 to current.
+func TestManagerIdentitySuffixMigration(t *testing.T) {
+	cfg, k8sClient, mgr, _, cleanup := setupTestEnvironment(t)
+	defer cleanup()
+
+	testNamespace := createTestNamespace(t, k8sClient)
+	defer cleanupTestNamespace(t, cfg, k8sClient, testNamespace)
+
+	dc := dynamicconfig.NewMemoryClient()
+	dc.OverrideValue(dynamicconfig.MakeKey("matching.wv.VersionDrainageStatusVisibilityGracePeriod"), testDrainageVisibilityGracePeriod)
+	dc.OverrideValue(dynamicconfig.MakeKey("matching.wv.VersionDrainageStatusRefreshInterval"), testDrainageRefreshInterval)
+	dc.OverrideValue(dynamicconfig.MakeKey("matching.maxVersionsInDeployment"), testMaxVersionsInDeployment)
+	dc.OverrideValue(dynamicconfig.MakeKey("history.enableVersionReactivationSignals"), false)
+	ts := temporaltest.NewServer(
+		temporaltest.WithT(t),
+		temporaltest.WithBaseServerOptions(temporal.WithDynamicConfigClient(dc)),
+	)
+
+	// Before the upgrade the controller identity is testControllerIdentity
+	// ("test-controller-identity/123"). Simulate an upgrade that changes the suffix.
+	const newSuffix = "sa-uid"
+	newIdentity := testControllerIdentityPrefix + "/" + newSuffix
+
+	ctx := context.Background()
+	builder := testhelpers.NewTestCase().
+		WithInput(
+			testhelpers.NewWorkerDeploymentBuilder().
+				WithAllAtOnceStrategy().
+				WithGate(true).
+				WithTargetTemplate("v1").
+				WithStatus(
+					testhelpers.NewStatusBuilder().
+						WithTargetVersion("v0", temporaliov1alpha1.VersionStatusCurrent, -1, true, true).
+						WithCurrentVersion("v0", true, true),
+				),
+		).
+		WithExistingDeployments(
+			testhelpers.NewDeploymentInfo("v0", 1),
+		).
+		WithSetupFunction(simulateIdentitySuffixUpgrade(testControllerIdentitySuffix, newSuffix)).
+		WithWaitTime(5 * time.Second).
+		// Desired: the controller re-claims under its new identity and promotes v1 to current,
+		// deprecating the previously-current v0.
+		WithExpectedStatus(
+			testhelpers.NewStatusBuilder().
+				WithTargetVersion("v1", temporaliov1alpha1.VersionStatusCurrent, -1, true, false).
+				WithCurrentVersion("v1", true, false).
+				WithDeprecatedVersions(
+					testhelpers.NewDeprecatedVersionInfo("v0", temporaliov1alpha1.VersionStatusDrained, true, false, true),
+				),
+		).
+		WithExpectedDeployments(
+			testhelpers.NewDeploymentInfo("v0", 1),
+		).
+		// The deployment is re-claimed under the post-upgrade identity.
+		WithValidatorFunction(validateManagerIdentity(newIdentity))
+
+	testWorkerDeploymentCreation(ctx, t, k8sClient, mgr, ts,
+		builder.BuildWithValues("manager-identity-suffix-change", testNamespace.Name, ts.GetDefaultNamespace()))
+}

--- a/internal/tests/internal/manager_identity_migration_integration_test.go
+++ b/internal/tests/internal/manager_identity_migration_integration_test.go
@@ -1,0 +1,120 @@
+package internal
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	temporaliov1alpha1 "github.com/temporalio/temporal-worker-controller/api/v1alpha1"
+	"github.com/temporalio/temporal-worker-controller/internal/controller"
+	"github.com/temporalio/temporal-worker-controller/internal/k8s"
+	"github.com/temporalio/temporal-worker-controller/internal/testhelpers"
+	temporalClient "go.temporal.io/sdk/client"
+	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/temporal"
+	"go.temporal.io/server/temporaltest"
+)
+
+// simulateIdentitySuffixUpgrade simulates a helm upgrade that changes the controller's
+// identity suffix (the ns-UID -> SA-UID change). It claims the Worker Deployment's manager
+// identity as the controller's pre-upgrade identity (prefix + legacySuffix), then sets the
+// running reconciler's new primary suffix while retaining the previous suffix as the legacy
+// suffix, exactly as the upgraded main() does.
+func simulateIdentitySuffixUpgrade(legacySuffix, newSuffix string) func(t *testing.T, ctx context.Context, tc testhelpers.TestCase, env testhelpers.TestEnv) {
+	return func(t *testing.T, ctx context.Context, tc testhelpers.TestCase, env testhelpers.TestEnv) {
+		legacyIdentity := testControllerIdentityPrefix + "/" + legacySuffix
+		workerDeploymentName := k8s.ComputeWorkerDeploymentName(tc.GetTWD())
+		c, err := temporalClient.Dial(temporalClient.Options{
+			HostPort:  env.Ts.GetFrontendHostPort(),
+			Namespace: env.Ts.GetDefaultNamespace(),
+			Identity:  legacyIdentity,
+		})
+		if err != nil {
+			t.Fatalf("failed to dial temporal with identity %q: %v", legacyIdentity, err)
+		}
+		defer c.Close()
+
+		if _, err := c.WorkerDeploymentClient().GetHandle(workerDeploymentName).SetManagerIdentity(ctx,
+			temporalClient.WorkerDeploymentSetManagerIdentityOptions{Self: true}); err != nil {
+			t.Fatalf("failed to claim manager identity %q: %v", legacyIdentity, err)
+		}
+		t.Logf("claimed manager identity as pre-upgrade identity %q", legacyIdentity)
+
+		// Upgraded controller: new SA-UID primary suffix, previous ns-UID suffix retained as
+		// the legacy suffix so the deployment can be re-claimed instead of deadlocking.
+		t.Setenv(controller.IdentitySuffixEnvKey, newSuffix)
+		t.Setenv(controller.LegacyIdentitySuffixEnvKey, legacySuffix)
+		t.Logf("upgraded identity suffix %q -> %q (legacy suffix retained)", legacySuffix, newSuffix)
+	}
+}
+
+// TestManagerIdentitySuffixMigration exercises a helm upgrade that changes the controller
+// identity suffix, as the namespace-UID -> ServiceAccount-UID change does.
+//
+// A Worker Deployment already managed under the pre-upgrade identity should remain
+// manageable after the suffix changes: the controller must be able to promote a new
+// version. Without a migration path the controller does not re-claim the deployment and
+// Temporal blocks routing changes from the new identity, so v1 is never promoted to
+// current (the manager-identity deadlock raised in review).
+//
+// This test asserts the desired post-migration behaviour: after the suffix change the
+// controller re-claims the deployment under its new identity and promotes v1 to current.
+func TestManagerIdentitySuffixMigration(t *testing.T) {
+	cfg, k8sClient, mgr, _, cleanup := setupTestEnvironment(t)
+	defer cleanup()
+
+	testNamespace := createTestNamespace(t, k8sClient)
+	defer cleanupTestNamespace(t, cfg, k8sClient, testNamespace)
+
+	dc := dynamicconfig.NewMemoryClient()
+	dc.OverrideValue(dynamicconfig.MakeKey("matching.wv.VersionDrainageStatusVisibilityGracePeriod"), testDrainageVisibilityGracePeriod)
+	dc.OverrideValue(dynamicconfig.MakeKey("matching.wv.VersionDrainageStatusRefreshInterval"), testDrainageRefreshInterval)
+	dc.OverrideValue(dynamicconfig.MakeKey("matching.maxVersionsInDeployment"), testMaxVersionsInDeployment)
+	dc.OverrideValue(dynamicconfig.MakeKey("history.enableVersionReactivationSignals"), false)
+	ts := temporaltest.NewServer(
+		temporaltest.WithT(t),
+		temporaltest.WithBaseServerOptions(temporal.WithDynamicConfigClient(dc)),
+	)
+
+	// Before the upgrade the controller identity is testControllerIdentity
+	// ("test-controller-identity/123"). Simulate an upgrade that changes the suffix.
+	const newSuffix = "sa-uid"
+	newIdentity := testControllerIdentityPrefix + "/" + newSuffix
+
+	ctx := context.Background()
+	builder := testhelpers.NewTestCase().
+		WithInput(
+			testhelpers.NewWorkerDeploymentBuilder().
+				WithAllAtOnceStrategy().
+				WithGate(true).
+				WithTargetTemplate("v1").
+				WithStatus(
+					testhelpers.NewStatusBuilder().
+						WithTargetVersion("v0", temporaliov1alpha1.VersionStatusCurrent, -1, true, true).
+						WithCurrentVersion("v0", true, true),
+				),
+		).
+		WithExistingDeployments(
+			testhelpers.NewDeploymentInfo("v0", 1),
+		).
+		WithSetupFunction(simulateIdentitySuffixUpgrade(testControllerIdentitySuffix, newSuffix)).
+		WithWaitTime(5 * time.Second).
+		// Desired: the controller re-claims under its new identity and promotes v1 to current,
+		// deprecating the previously-current v0.
+		WithExpectedStatus(
+			testhelpers.NewStatusBuilder().
+				WithTargetVersion("v1", temporaliov1alpha1.VersionStatusCurrent, -1, true, false).
+				WithCurrentVersion("v1", true, false).
+				WithDeprecatedVersions(
+					testhelpers.NewDeprecatedVersionInfo("v0", temporaliov1alpha1.VersionStatusDrained, true, false, true),
+				),
+		).
+		WithExpectedDeployments(
+			testhelpers.NewDeploymentInfo("v0", 1),
+		).
+		// The deployment is re-claimed under the post-upgrade identity.
+		WithValidatorFunction(validateManagerIdentity(newIdentity))
+
+	testWorkerDeploymentCreation(ctx, t, k8sClient, mgr, ts,
+		builder.BuildWithValues("manager-identity-suffix-change", testNamespace.Name, ts.GetDefaultNamespace()))
+}


### PR DESCRIPTION
<!--- For ALL Contributors 👇 -->

## What was changed

Two changes toward reducing the cluster-scoped RBAC the controller needs in
namespace-scoped mode (`rbac.restrictWatchNamespaces`), without breaking existing installs on
upgrade:

1. **`SubjectAccessReview` → `LocalSubjectAccessReview`** in the WorkerResourceTemplate
   webhook. It is namespaced and sufficient (the webhook rejects non-namespaced kinds and
   always checks within the object's namespace), so `subjectaccessreviews create` moves out
   of the cluster-scoped grant into the per-namespace Role.

2. **Identity suffix from the ServiceAccount UID instead of the Namespace UID**, read via a
   small namespaced `identity-reader-role`. A plain suffix change would deadlock existing
   Worker Deployments (they stay managed under the old identity — thanks @jaypipes), so the
   controller also reads the namespace UID and treats the old `id/<ns-uid>` identity as
   reclaimable, the same pattern as the existing `getDeprecatedControllerIdentity` reclaim
   from #308. On `helm upgrade` it re-adopts existing deployments under the new `id/<sa-uid>`
   identity automatically.

The `namespaces get` grant (a minimal `manager-cluster-role`) is retained for this migration
window; it can be dropped in a follow-up release once deployments have been re-adopted, at
which point namespace-scoped mode no longer needs a manager ClusterRole.

## Why?

Clusters whose policies forbid ClusterRole creation (common in the multi-tenant environments
namespace-scoped mode targets) currently can't install the chart. Both grants are ClusterRoles
only because their resource types are cluster-scoped, not because the controller needs
cluster-wide reach. This removes one now and sets up removing the other safely.

## Checklist

1. Closes #530

2. How was this tested:
   - New integration test (`TestManagerIdentitySuffixMigration`) reproduces the upgrade
     against a real Temporal server (`temporaltest`): it fails (deadlock) without the reclaim
     path and passes with it (re-claims and promotes the new version). The full
     `TestIntegration` suite passes with the change (no regression to the existing
     manager-identity tests).
   - `make manifests` is idempotent (CI rbac.yaml gate passes).
   - `helm template` (namespace-scoped): the manager is a namespaced Role; `manager-cluster-role`
     now holds only `namespaces get`; a new namespaced `identity-reader-role` is added; no
     `subjectaccessreviews` cluster grant.
   - Webhook + controller envtest suites pass.

3. Any docs updates needed?
   Probably a short note in the namespace-scoped/RBAC docs about the reduced ClusterRole and
   the planned follow-up removal. Happy to add.
