### PR TITLE
fix(controller): watch Connection to clear stale TemporalConnection status

### DIFF
--- a/internal/controller/deprecated_tc_reconciler.go
+++ b/internal/controller/deprecated_tc_reconciler.go
@@ -9,6 +9,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 )
 
 // +kubebuilder:rbac:groups=temporal.io,resources=temporalconnections,verbs=get;list;watch;update;patch
@@ -110,6 +111,11 @@ func (r *DeprecatedTCReconciler) Reconcile(ctx context.Context, req ctrl.Request
 func (r *DeprecatedTCReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&temporaliov1alpha1.TemporalConnection{}).
+		// A Connection is the replacement for the same-named TemporalConnection,
+		// so creating one changes the deprecated resource's status. Without this
+		// watch that status stays stale until an unrelated event happens to
+		// trigger a reconcile.
+		Watches(&temporaliov1alpha1.Connection{}, &handler.EnqueueRequestForObject{}).
 		Named("deprecated-tc").
 		Complete(r)
 }


### PR DESCRIPTION
While migrating our clusters across the 0.26.0 CRD rename, our deprecated
`TemporalConnection` objects got stuck reporting `reason=Deprecated` — still asking us to create a
`Connection` that already existed. Unsticking them meant a meaningless annotation to force a
reconcile:

```bash
kubectl -n <ns> annotate temporalconnections.temporal.io temporal-cloud migration-poke=retry --overwrite
```

All of them flipped to `MigratedToConnection` within about twenty seconds, so the status logic is
right — only the trigger was missing. `DeprecatedTCReconciler` watched just its own kind, and
nothing outside that reconciler ever writes to a `TemporalConnection`, so creating the `Connection`
never enqueued it.

This PR adds a watch on `Connection` so the replacement enqueues the deprecated resource. Names are
1:1, so `EnqueueRequestForObject` maps it directly, and no RBAC change is needed — the reconciler
already declares `get;list;watch` on connections.

`DeprecatedTWDReconciler` has the same missing watch but does not need it in practice:
`migrateFromDeprecatedTWD` patches the `migrated-to-wd` label onto the deprecated object, and that
write wakes the reconciler. Connections have no equivalent write, so they need the nudge.

Closes #548
