### PR TITLE
Make controller more resilient to inconsistent Temporal state, delay requeue after Temporal ResourceExhausted, improve logs

### DIFF
--- a/api/v1alpha1/workerdeployment_types.go
+++ b/api/v1alpha1/workerdeployment_types.go
@@ -151,8 +151,14 @@ type VersionStatus string
 
 const (
 	// VersionStatusNotRegistered indicates that the version is not registered
-	// with Temporal for any worker deployment.
+	// with Temporal for any worker deployment. It may be not yet created, or
+	// may have been deleted.
 	VersionStatusNotRegistered VersionStatus = "NotRegistered"
+
+	// VersionStatusCreated indicates that the version has been created explicitly.
+	// When the first poll requests for this version come in, the version status
+	// will change to Inactive.
+	VersionStatusCreated VersionStatus = "Created"
 
 	// VersionStatusInactive indicates that the version is registered in a Temporal
 	// worker deployment, but has not been set to current or ramping.

--- a/internal/controller/execplan.go
+++ b/internal/controller/execplan.go
@@ -99,8 +99,8 @@ func (r *WorkerDeploymentReconciler) executeK8sOperations(ctx context.Context, l
 	for d, replicas := range p.ScaleDeployments {
 		buildID := buildIDForDeployment(workerDeploy, d)
 		l.Info(
-			fmt.Sprintf("scaling deployment %q for Build ID %q to %d replicas", d.Name, buildID, replicas),
-			"deployment", d.Name,
+			"scaling deployment",
+			"deployment", d,
 			"buildID", buildID,
 			"replicas", replicas,
 		)
@@ -115,8 +115,8 @@ func (r *WorkerDeploymentReconciler) executeK8sOperations(ctx context.Context, l
 		if err := r.Client.SubResource("scale").Update(ctx, dep, client.WithSubResourceBody(scale)); err != nil {
 			l.Error(
 				err,
-				fmt.Sprintf("unable to scale deployment %q for Build ID %q to %d replicas", d.Name, buildID, replicas),
-				"deployment", d.Name,
+				"unable to scale deployment",
+				"deployment", d,
 				"buildID", buildID,
 				"replicas", replicas,
 			)

--- a/internal/controller/execplan.go
+++ b/internal/controller/execplan.go
@@ -143,6 +143,7 @@ func (r *WorkerDeploymentReconciler) executeK8sOperations(ctx context.Context, l
 func buildIDForDeployment(workerDeploy *temporaliov1alpha1.WorkerDeployment, deployment *corev1.ObjectReference) string {
 	matches := func(versionDeployment *corev1.ObjectReference) bool {
 		return versionDeployment != nil &&
+			deployment != nil &&
 			versionDeployment.Namespace == deployment.Namespace &&
 			versionDeployment.Name == deployment.Name
 	}

--- a/internal/controller/execplan.go
+++ b/internal/controller/execplan.go
@@ -97,7 +97,13 @@ func (r *WorkerDeploymentReconciler) executeK8sOperations(ctx context.Context, l
 
 	// Scale deployments
 	for d, replicas := range p.ScaleDeployments {
-		l.Info("scaling deployment", "deployment", d, "replicas", replicas)
+		buildID := buildIDForDeployment(workerDeploy, d)
+		l.Info(
+			fmt.Sprintf("scaling deployment %q for Build ID %q to %d replicas", d.Name, buildID, replicas),
+			"deployment", d.Name,
+			"buildID", buildID,
+			"replicas", replicas,
+		)
 		dep := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
 			Namespace:       d.Namespace,
 			Name:            d.Name,
@@ -107,9 +113,15 @@ func (r *WorkerDeploymentReconciler) executeK8sOperations(ctx context.Context, l
 
 		scale := &autoscalingv1.Scale{Spec: autoscalingv1.ScaleSpec{Replicas: int32(replicas)}}
 		if err := r.Client.SubResource("scale").Update(ctx, dep, client.WithSubResourceBody(scale)); err != nil {
-			l.Error(err, "unable to scale deployment", "deployment", d, "replicas", replicas)
+			l.Error(
+				err,
+				fmt.Sprintf("unable to scale deployment %q for Build ID %q to %d replicas", d.Name, buildID, replicas),
+				"deployment", d.Name,
+				"buildID", buildID,
+				"replicas", replicas,
+			)
 			r.Recorder.Eventf(workerDeploy, corev1.EventTypeWarning, ReasonDeploymentScaleFailed,
-				"Failed to scale Deployment %q to %d replicas: %v", d.Name, replicas, err)
+				"Failed to scale Deployment %q for Build ID %q to %d replicas: %v", d.Name, buildID, replicas, err)
 			return deletedWorkerResources, fmt.Errorf("unable to scale deployment: %w", err)
 		}
 	}
@@ -126,6 +138,27 @@ func (r *WorkerDeploymentReconciler) executeK8sOperations(ctx context.Context, l
 	}
 
 	return deletedWorkerResources, nil
+}
+
+func buildIDForDeployment(workerDeploy *temporaliov1alpha1.WorkerDeployment, deployment *corev1.ObjectReference) string {
+	matches := func(versionDeployment *corev1.ObjectReference) bool {
+		return versionDeployment != nil &&
+			versionDeployment.Namespace == deployment.Namespace &&
+			versionDeployment.Name == deployment.Name
+	}
+
+	if matches(workerDeploy.Status.TargetVersion.Deployment) {
+		return workerDeploy.Status.TargetVersion.BuildID
+	}
+	if workerDeploy.Status.CurrentVersion != nil && matches(workerDeploy.Status.CurrentVersion.Deployment) {
+		return workerDeploy.Status.CurrentVersion.BuildID
+	}
+	for _, version := range workerDeploy.Status.DeprecatedVersions {
+		if version != nil && matches(version.Deployment) {
+			return version.BuildID
+		}
+	}
+	return "unknown"
 }
 
 func (r *WorkerDeploymentReconciler) startTestWorkflows(ctx context.Context, l logr.Logger, workerDeploy *temporaliov1alpha1.WorkerDeployment, temporalClient sdkclient.Client, p *plan) error {

--- a/internal/controller/reconciler_events_test.go
+++ b/internal/controller/reconciler_events_test.go
@@ -759,6 +759,31 @@ func TestExecuteK8sOperations_EmitsEventOnFailure(t *testing.T) {
 	}
 }
 
+func TestBuildIDForDeployment(t *testing.T) {
+	targetRef := &corev1.ObjectReference{Namespace: "default", Name: "target"}
+	currentRef := &corev1.ObjectReference{Namespace: "default", Name: "current"}
+	deprecatedRef := &corev1.ObjectReference{Namespace: "default", Name: "deprecated"}
+	twd := makeWD("test-worker", "default", "my-conn")
+	twd.Status.TargetVersion.BuildID, twd.Status.TargetVersion.Deployment = "target-build", targetRef
+	twd.Status.CurrentVersion = &temporaliov1alpha1.CurrentWorkerDeploymentVersion{BaseWorkerDeploymentVersion: temporaliov1alpha1.BaseWorkerDeploymentVersion{BuildID: "current-build", Deployment: currentRef}}
+	twd.Status.DeprecatedVersions = []*temporaliov1alpha1.DeprecatedWorkerDeploymentVersion{{BaseWorkerDeploymentVersion: temporaliov1alpha1.BaseWorkerDeploymentVersion{BuildID: "deprecated-build", Deployment: deprecatedRef}}}
+
+	tests := map[string]struct {
+		deployment *corev1.ObjectReference
+		buildID    string
+	}{
+		"target":     {targetRef, "target-build"},
+		"current":    {currentRef, "current-build"},
+		"deprecated": {deprecatedRef, "deprecated-build"},
+		"unknown":    {&corev1.ObjectReference{Namespace: "default", Name: "unknown"}, "unknown"},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tt.buildID, buildIDForDeployment(twd, tt.deployment))
+		})
+	}
+}
+
 // ─── startTestWorkflows tests ────────────────────────────────────────────────
 
 func TestStartTestWorkflows_StartFailed_EmitsEvent(t *testing.T) {

--- a/internal/controller/worker_controller.go
+++ b/internal/controller/worker_controller.go
@@ -323,8 +323,8 @@ func (r *WorkerDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		if errors.As(err, &rateLimitErr) {
 			r.recordWarningAndSetBlocked(ctx, &workerDeploy,
 				temporaliov1alpha1.ReasonTemporalStateFetchFailed,
-				fmt.Sprintf("Rate limited fetching worker deployment state: %v", err),
-				fmt.Sprintf("Rate limited by Temporal server: %v", err))
+				fmt.Sprintf("Got ResourceExhausted error fetching worker deployment state from Temporal server: %v", err),
+				fmt.Sprintf("Got ResourceExhausted error fetching worker deployment state from Temporal server: %v", err))
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 		}
 		r.recordWarningAndSetBlocked(ctx, &workerDeploy,
@@ -364,6 +364,14 @@ func (r *WorkerDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	if err := r.executePlan(ctx, l, &workerDeploy, temporalClient, plan); err != nil {
 		if isAccessDeniedErr(err) {
 			r.TemporalClientPool.EvictClient(clientPoolKey)
+		}
+		var rateLimitErr *serviceerror.ResourceExhausted
+		if errors.As(err, &rateLimitErr) {
+			r.recordWarningAndSetBlocked(ctx, &workerDeploy,
+				ReasonPlanExecutionFailed,
+				fmt.Sprintf("Got ResourceExhausted error executing plan: %v", err),
+				fmt.Sprintf("Got ResourceExhausted error executing plan: %v", err))
+			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 		}
 		r.recordWarningAndSetBlocked(ctx, &workerDeploy,
 			ReasonPlanExecutionFailed,

--- a/internal/controller/worker_controller.go
+++ b/internal/controller/worker_controller.go
@@ -307,6 +307,7 @@ func (r *WorkerDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	// Fetch Temporal worker deployment state
 	temporalState, err := temporal.GetWorkerDeploymentState(
 		ctx,
+		l,
 		temporalClient,
 		workerDeploymentName,
 		workerDeploy.Spec.WorkerOptions.TemporalNamespace,

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -767,6 +767,7 @@ func getDeleteDeployments(
 				// NotRegistered versions are versions that the server doesn't know about.
 				// Only delete if it's not the target version.
 				status.TargetVersion.BuildID != version.BuildID {
+				// Consider: Could call DescribeVersion here to assert NotFound before deleting, in case version summaries have diverged from version state
 				deleteDeployments = append(deleteDeployments, d)
 			}
 		}

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -921,10 +921,11 @@ func getTestWorkflows(
 	var testWorkflows []WorkflowConfig
 
 	// Skip if there's no gate workflow defined, if the target version is already the current, or if the target
-	// version is not yet registered in temporal
+	// version is not yet ready to run workflows
 	if config.RolloutStrategy.Gate == nil ||
 		(status.CurrentVersion != nil && status.CurrentVersion.BuildID == status.TargetVersion.BuildID) ||
-		status.TargetVersion.Status == temporaliov1alpha1.VersionStatusNotRegistered {
+		status.TargetVersion.Status == temporaliov1alpha1.VersionStatusNotRegistered ||
+		status.TargetVersion.Status == temporaliov1alpha1.VersionStatusCreated {
 		return nil
 	}
 
@@ -973,9 +974,12 @@ func getVersionConfigDiff(
 		return nil
 	}
 
-	// Do nothing if target version's deployment is not healthy yet, or if the version is not yet registered in temporal
+	// Do nothing if the target Deployment is not healthy yet, or until Temporal reports
+	// the version as Inactive, indicating that workers have started polling. Created
+	// versions exist in Temporal but do not have pollers yet.
 	if status.TargetVersion.HealthySince == nil ||
-		status.TargetVersion.Status == temporaliov1alpha1.VersionStatusNotRegistered {
+		status.TargetVersion.Status == temporaliov1alpha1.VersionStatusNotRegistered ||
+		status.TargetVersion.Status == temporaliov1alpha1.VersionStatusCreated {
 		return nil
 	}
 

--- a/internal/planner/planner_test.go
+++ b/internal/planner/planner_test.go
@@ -1398,6 +1398,26 @@ func TestGetTestWorkflows(t *testing.T) {
 			expectWorkflows: 0,
 		},
 		{
+			name: "created version is not ready for gate workflows",
+			status: &temporaliov1alpha1.WorkerDeploymentStatus{
+				TargetVersion: temporaliov1alpha1.TargetWorkerDeploymentVersion{
+					BaseWorkerDeploymentVersion: temporaliov1alpha1.BaseWorkerDeploymentVersion{
+						BuildID: "123",
+						Status:  temporaliov1alpha1.VersionStatusCreated,
+						TaskQueues: []temporaliov1alpha1.TaskQueue{
+							{Name: "queue1"},
+						},
+					},
+				},
+			},
+			config: &Config{
+				RolloutStrategy: temporaliov1alpha1.RolloutStrategy{
+					Gate: &temporaliov1alpha1.GateWorkflowConfig{WorkflowType: "TestWorkflow"},
+				},
+			},
+			expectWorkflows: 0,
+		},
+		{
 			name: "gate workflow with empty task queues",
 			status: &temporaliov1alpha1.WorkerDeploymentStatus{
 				TargetVersion: temporaliov1alpha1.TargetWorkerDeploymentVersion{
@@ -1494,6 +1514,29 @@ func TestGetVersionConfigDiff(t *testing.T) {
 			spec:             &temporaliov1alpha1.WorkerDeploymentSpec{},
 			expectConfig:     true,
 			expectSetCurrent: true,
+		},
+		{
+			name: "created version waits for pollers",
+			strategy: temporaliov1alpha1.RolloutStrategy{
+				Strategy: temporaliov1alpha1.UpdateAllAtOnce,
+			},
+			status: &temporaliov1alpha1.WorkerDeploymentStatus{
+				TargetVersion: temporaliov1alpha1.TargetWorkerDeploymentVersion{
+					BaseWorkerDeploymentVersion: temporaliov1alpha1.BaseWorkerDeploymentVersion{
+						BuildID:      "test/namespace.123",
+						Status:       temporaliov1alpha1.VersionStatusCreated,
+						HealthySince: &metav1.Time{Time: time.Now().Add(-1 * time.Hour)},
+					},
+				},
+				CurrentVersion: &temporaliov1alpha1.CurrentWorkerDeploymentVersion{
+					BaseWorkerDeploymentVersion: temporaliov1alpha1.BaseWorkerDeploymentVersion{
+						BuildID: "456",
+						Status:  temporaliov1alpha1.VersionStatusCurrent,
+					},
+				},
+			},
+			spec:         &temporaliov1alpha1.WorkerDeploymentSpec{},
+			expectConfig: false,
 		},
 		{
 			name: "progressive strategy",

--- a/internal/temporal/worker_deployment.go
+++ b/internal/temporal/worker_deployment.go
@@ -166,6 +166,7 @@ func versionInfoFromVersionSummary(
 	case enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_CREATED:
 		out.Status = temporaliov1alpha1.VersionStatusCreated
 	case enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_INACTIVE:
+		out.Status = temporaliov1alpha1.VersionStatusInactive
 		// get unversioned poller info to decide whether to fast-track rollout
 		if summary.DeploymentVersion.BuildId == targetBuildID &&
 			routingConfig.CurrentDeploymentVersion == nil &&

--- a/internal/temporal/worker_deployment.go
+++ b/internal/temporal/worker_deployment.go
@@ -140,6 +140,17 @@ func GetWorkerDeploymentState(
 	return state, nil
 }
 
+// versionStatusMap translates between the temporal SDK VersionStatus and the
+// TWC k8s API VersionStatus
+var versionStatusMap = map[enumspb.WorkerDeploymentVersionStatus]temporaliov1alpha1.VersionStatus{
+	enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_CURRENT:     temporaliov1alpha1.VersionStatusCurrent,
+	enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_DRAINING:    temporaliov1alpha1.VersionStatusDraining,
+	enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_DRAINED:     temporaliov1alpha1.VersionStatusDrained,
+	enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_INACTIVE:    temporaliov1alpha1.VersionStatusInactive,
+	enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_RAMPING:     temporaliov1alpha1.VersionStatusRamping,
+	enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_UNSPECIFIED: temporaliov1alpha1.VersionStatusNotRegistered,
+}
+
 // versionInfoFromVersionSummary returns a VersionInfo constructed from the
 // supplied Temporal VersionSummary message.
 //
@@ -159,14 +170,43 @@ func versionInfoFromVersionSummary(
 		BuildID:        summary.DeploymentVersion.BuildId,
 	}
 
-	// Determine summary status
-	switch summary.GetStatus() {
-	case enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_UNSPECIFIED:
-		out.Status = temporaliov1alpha1.VersionStatusNotRegistered
-	case enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_CREATED:
-		out.Status = temporaliov1alpha1.VersionStatusCreated
-	case enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_INACTIVE:
-		out.Status = temporaliov1alpha1.VersionStatusInactive
+	apiVersionStatus, ok := versionStatusMap[summary.GetStatus()]
+	if !ok {
+		l.Error(fmt.Errorf("unknown worker version status %s", summary.GetStatus()), "unable to determine version status")
+		return nil
+	}
+	out.Status = apiVersionStatus
+
+	sumDeploymentName := summary.DeploymentVersion.DeploymentName
+	sumBuildID := summary.DeploymentVersion.BuildId
+
+	// There may be inconsistencies in the data returned from temporal server. Check
+	// for these inconsistencies and warn if found.
+	if apiVersionStatus == temporaliov1alpha1.VersionStatusCurrent {
+		if routingConfig.CurrentDeploymentVersion != nil {
+			rcDeployName := routingConfig.CurrentDeploymentVersion.DeploymentName
+			rcBuildID := routingConfig.CurrentDeploymentVersion.BuildId
+			if sumDeploymentName != rcDeployName || sumBuildID != rcBuildID {
+				l.Info(
+					"warning: version reports Current but routing config identifies a different Current version; trusting routing config",
+					"buildID", sumBuildID,
+					"routingConfigBuildID", rcBuildID,
+				)
+			}
+		}
+	} else if apiVersionStatus == temporaliov1alpha1.VersionStatusRamping {
+		if routingConfig.RampingDeploymentVersion != nil {
+			rcDeployName := routingConfig.RampingDeploymentVersion.DeploymentName
+			rcBuildID := routingConfig.RampingDeploymentVersion.BuildId
+			if sumDeploymentName != rcDeployName || sumBuildID != rcBuildID {
+				l.Info(
+					"warning: version reports Ramping but routing config identifies a different Ramping version; trusting routing config",
+					"buildID", sumBuildID,
+					"routingConfigBuildID", rcBuildID,
+				)
+			}
+		}
+	} else if apiVersionStatus == temporaliov1alpha1.VersionStatusInactive {
 		// get unversioned poller info to decide whether to fast-track rollout
 		if summary.DeploymentVersion.BuildId == targetBuildID &&
 			routingConfig.CurrentDeploymentVersion == nil &&
@@ -194,36 +234,7 @@ func versionInfoFromVersionSummary(
 			// NOTE(jaypipes): We swallow any non-nil error here. Should we
 			// at least log the error?
 		}
-	case enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_RAMPING:
-		if routingConfig.RampingDeploymentVersion != nil &&
-			summary.DeploymentVersion.DeploymentName == routingConfig.RampingDeploymentVersion.DeploymentName &&
-			summary.DeploymentVersion.BuildId == routingConfig.RampingDeploymentVersion.BuildId {
-			out.Status = temporaliov1alpha1.VersionStatusRamping
-		} else {
-			l.Error(
-				errors.New("worker deployment version status conflicts with routing config"),
-				"version reports Ramping but routing config identifies a different Ramping version; trusting routing config",
-				"buildID", summary.DeploymentVersion.BuildId,
-				"routingConfigBuildID", routingConfig.RampingDeploymentVersion.BuildId,
-			)
-		}
-	case enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_CURRENT:
-		if routingConfig.CurrentDeploymentVersion != nil &&
-			summary.DeploymentVersion.DeploymentName == routingConfig.CurrentDeploymentVersion.DeploymentName &&
-			summary.DeploymentVersion.BuildId == routingConfig.CurrentDeploymentVersion.BuildId {
-			out.Status = temporaliov1alpha1.VersionStatusCurrent
-		} else {
-			l.Error(
-				errors.New("worker deployment version status conflicts with routing config"),
-				"version reports Current but routing config identifies a different Current version; trusting routing config",
-				"buildID", summary.DeploymentVersion.BuildId,
-				"routingConfigBuildID", routingConfig.CurrentDeploymentVersion.BuildId,
-			)
-		}
-	case enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_DRAINING:
-		out.Status = temporaliov1alpha1.VersionStatusDraining
-	case enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_DRAINED:
-		out.Status = temporaliov1alpha1.VersionStatusDrained
+	} else if apiVersionStatus == temporaliov1alpha1.VersionStatusDrained {
 		// Extract DrainedSince directly from the summary's drainage info,
 		// avoiding a per-summary DescribeVersion call.
 		if summary.DrainageInfo != nil && summary.DrainageInfo.LastChangedTime != nil {

--- a/internal/temporal/worker_deployment.go
+++ b/internal/temporal/worker_deployment.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-logr/logr"
 	temporaliov1alpha1 "github.com/temporalio/temporal-worker-controller/api/v1alpha1"
 	deploymentpb "go.temporal.io/api/deployment/v1"
 	enumspb "go.temporal.io/api/enums/v1"
@@ -63,6 +64,7 @@ type TemporalWorkerState struct {
 // GetWorkerDeploymentState queries Temporal to get the state of a worker deployment
 func GetWorkerDeploymentState(
 	ctx context.Context,
+	l logr.Logger,
 	client temporalClient.Client,
 	workerDeploymentName string,
 	namespace string,
@@ -129,7 +131,7 @@ func GetWorkerDeploymentState(
 
 	for _, version := range workerDeploymentInfo.VersionSummaries {
 		versionInfo := versionInfoFromVersionSummary(
-			ctx, client, targetBuildID, strategy,
+			ctx, l, client, targetBuildID, strategy,
 			depHandle, routingConfig, version,
 		)
 		state.Versions[version.DeploymentVersion.BuildId] = versionInfo
@@ -144,6 +146,7 @@ func GetWorkerDeploymentState(
 //nolint:revive // cyclomatic complexity acceptable given breadth of plan execution
 func versionInfoFromVersionSummary(
 	ctx context.Context,
+	l logr.Logger,
 	client temporalClient.Client,
 	targetBuildID string,
 	strategy temporaliov1alpha1.DefaultVersionUpdateStrategy,
@@ -196,7 +199,12 @@ func versionInfoFromVersionSummary(
 			summary.DeploymentVersion.BuildId == routingConfig.RampingDeploymentVersion.BuildId {
 			out.Status = temporaliov1alpha1.VersionStatusRamping
 		} else {
-			// TODO(carly-now): log error saying "version xxx thinks it is Ramping but routing config says yyy is Ramping. Trusting routing config more."
+			l.Error(
+				errors.New("worker deployment version status conflicts with routing config"),
+				"version reports Ramping but routing config identifies a different Ramping version; trusting routing config",
+				"buildID", summary.DeploymentVersion.BuildId,
+				"routingConfigBuildID", routingConfig.RampingDeploymentVersion.BuildId,
+			)
 		}
 	case enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_CURRENT:
 		if routingConfig.CurrentDeploymentVersion != nil &&
@@ -204,7 +212,12 @@ func versionInfoFromVersionSummary(
 			summary.DeploymentVersion.BuildId == routingConfig.CurrentDeploymentVersion.BuildId {
 			out.Status = temporaliov1alpha1.VersionStatusCurrent
 		} else {
-			// TODO(carly-now): log error saying "version xxx thinks it is Current but routing config says yyy is Current. Trusting routing config more."
+			l.Error(
+				errors.New("worker deployment version status conflicts with routing config"),
+				"version reports Current but routing config identifies a different Current version; trusting routing config",
+				"buildID", summary.DeploymentVersion.BuildId,
+				"routingConfigBuildID", routingConfig.CurrentDeploymentVersion.BuildId,
+			)
 		}
 	case enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_DRAINING:
 		out.Status = temporaliov1alpha1.VersionStatusDraining

--- a/internal/temporal/worker_deployment.go
+++ b/internal/temporal/worker_deployment.go
@@ -157,28 +157,12 @@ func versionInfoFromVersionSummary(
 	}
 
 	// Determine summary status
-	drainageStatus := summary.DrainageInfo.GetStatus()
-	if routingConfig.CurrentDeploymentVersion != nil &&
-		summary.DeploymentVersion.DeploymentName == routingConfig.CurrentDeploymentVersion.DeploymentName &&
-		summary.DeploymentVersion.BuildId == routingConfig.CurrentDeploymentVersion.BuildId {
-		out.Status = temporaliov1alpha1.VersionStatusCurrent
-	} else if routingConfig.RampingDeploymentVersion != nil &&
-		summary.DeploymentVersion.DeploymentName == routingConfig.RampingDeploymentVersion.DeploymentName &&
-		summary.DeploymentVersion.BuildId == routingConfig.RampingDeploymentVersion.BuildId {
-		out.Status = temporaliov1alpha1.VersionStatusRamping
-	} else if drainageStatus == enumspb.VERSION_DRAINAGE_STATUS_DRAINING {
-		out.Status = temporaliov1alpha1.VersionStatusDraining
-	} else if drainageStatus == enumspb.VERSION_DRAINAGE_STATUS_DRAINED {
-		out.Status = temporaliov1alpha1.VersionStatusDrained
-
-		// Extract DrainedSince directly from the summary's drainage info,
-		// avoiding a per-summary DescribeVersion call.
-		if summary.DrainageInfo != nil && summary.DrainageInfo.LastChangedTime != nil {
-			drainedSince := summary.DrainageInfo.LastChangedTime.AsTime()
-			out.DrainedSince = &drainedSince
-		}
-	} else {
-		out.Status = temporaliov1alpha1.VersionStatusInactive
+	switch summary.GetStatus() {
+	case enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_UNSPECIFIED:
+		out.Status = temporaliov1alpha1.VersionStatusNotRegistered
+	case enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_CREATED:
+		out.Status = temporaliov1alpha1.VersionStatusCreated
+	case enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_INACTIVE:
 		// get unversioned poller info to decide whether to fast-track rollout
 		if summary.DeploymentVersion.BuildId == targetBuildID &&
 			routingConfig.CurrentDeploymentVersion == nil &&
@@ -205,6 +189,32 @@ func versionInfoFromVersionSummary(
 			}
 			// NOTE(jaypipes): We swallow any non-nil error here. Should we
 			// at least log the error?
+		}
+	case enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_RAMPING:
+		if routingConfig.RampingDeploymentVersion != nil &&
+			summary.DeploymentVersion.DeploymentName == routingConfig.RampingDeploymentVersion.DeploymentName &&
+			summary.DeploymentVersion.BuildId == routingConfig.RampingDeploymentVersion.BuildId {
+			out.Status = temporaliov1alpha1.VersionStatusRamping
+		} else {
+			// TODO(carly-now): log error saying "version xxx thinks it is Ramping but routing config says yyy is Ramping. Trusting routing config more."
+		}
+	case enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_CURRENT:
+		if routingConfig.CurrentDeploymentVersion != nil &&
+			summary.DeploymentVersion.DeploymentName == routingConfig.CurrentDeploymentVersion.DeploymentName &&
+			summary.DeploymentVersion.BuildId == routingConfig.CurrentDeploymentVersion.BuildId {
+			out.Status = temporaliov1alpha1.VersionStatusCurrent
+		} else {
+			// TODO(carly-now): log error saying "version xxx thinks it is Current but routing config says yyy is Current. Trusting routing config more."
+		}
+	case enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_DRAINING:
+		out.Status = temporaliov1alpha1.VersionStatusDraining
+	case enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_DRAINED:
+		out.Status = temporaliov1alpha1.VersionStatusDrained
+		// Extract DrainedSince directly from the summary's drainage info,
+		// avoiding a per-summary DescribeVersion call.
+		if summary.DrainageInfo != nil && summary.DrainageInfo.LastChangedTime != nil {
+			drainedSince := summary.DrainageInfo.LastChangedTime.AsTime()
+			out.DrainedSince = &drainedSince
 		}
 	}
 

--- a/internal/temporal/worker_deployment.go
+++ b/internal/temporal/worker_deployment.go
@@ -144,6 +144,7 @@ func GetWorkerDeploymentState(
 // TWC k8s API VersionStatus
 var versionStatusMap = map[enumspb.WorkerDeploymentVersionStatus]temporaliov1alpha1.VersionStatus{
 	enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_CURRENT:     temporaliov1alpha1.VersionStatusCurrent,
+	enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_CREATED:     temporaliov1alpha1.VersionStatusCreated,
 	enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_DRAINING:    temporaliov1alpha1.VersionStatusDraining,
 	enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_DRAINED:     temporaliov1alpha1.VersionStatusDrained,
 	enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_INACTIVE:    temporaliov1alpha1.VersionStatusInactive,

--- a/internal/temporal/worker_deployment_test.go
+++ b/internal/temporal/worker_deployment_test.go
@@ -5,13 +5,82 @@
 package temporal
 
 import (
+	"context"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/go-logr/logr/funcr"
 	"github.com/stretchr/testify/assert"
 	temporaliov1alpha1 "github.com/temporalio/temporal-worker-controller/api/v1alpha1"
+	deploymentpb "go.temporal.io/api/deployment/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 )
+
+func TestVersionInfoFromVersionSummaryLogsRoutingConfigStatusConflicts(t *testing.T) {
+	tests := []struct {
+		name                  string
+		summaryStatus         enumspb.WorkerDeploymentVersionStatus
+		routingConfig         *deploymentpb.RoutingConfig
+		reportedStatus        temporaliov1alpha1.VersionStatus
+		expectedLogMessage    string
+		expectedConfigBuildID string
+	}{
+		{
+			name:          "ramping",
+			summaryStatus: enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_RAMPING,
+			routingConfig: &deploymentpb.RoutingConfig{
+				RampingDeploymentVersion: &deploymentpb.WorkerDeploymentVersion{
+					DeploymentName: "workers",
+					BuildId:        "build-b",
+				},
+			},
+			reportedStatus:        temporaliov1alpha1.VersionStatusRamping,
+			expectedLogMessage:    "version reports Ramping but routing config identifies a different Ramping version; trusting routing config",
+			expectedConfigBuildID: "build-b",
+		},
+		{
+			name:          "current",
+			summaryStatus: enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_CURRENT,
+			routingConfig: &deploymentpb.RoutingConfig{
+				CurrentDeploymentVersion: &deploymentpb.WorkerDeploymentVersion{
+					DeploymentName: "workers",
+					BuildId:        "build-b",
+				},
+			},
+			reportedStatus:        temporaliov1alpha1.VersionStatusCurrent,
+			expectedLogMessage:    "version reports Current but routing config identifies a different Current version; trusting routing config",
+			expectedConfigBuildID: "build-b",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var logLines []string
+			logger := funcr.New(func(prefix, args string) {
+				logLines = append(logLines, prefix+" "+args)
+			}, funcr.Options{})
+			summary := &deploymentpb.WorkerDeploymentInfo_WorkerDeploymentVersionSummary{
+				DeploymentVersion: &deploymentpb.WorkerDeploymentVersion{
+					DeploymentName: "workers",
+					BuildId:        "build-a",
+				},
+				Status: tt.summaryStatus,
+			}
+
+			info := versionInfoFromVersionSummary(
+				context.Background(), logger, nil, "", "", nil, tt.routingConfig, summary,
+			)
+
+			assert.NotEqual(t, tt.reportedStatus, info.Status)
+			logs := strings.Join(logLines, "\n")
+			assert.Contains(t, logs, tt.expectedLogMessage)
+			assert.Contains(t, logs, "build-a")
+			assert.Contains(t, logs, tt.expectedConfigBuildID)
+			assert.NotContains(t, logs, "workers:")
+		})
+	}
+}
 
 func TestMapWorkflowStatus(t *testing.T) {
 	tests := []struct {

--- a/internal/temporal/worker_deployment_test.go
+++ b/internal/temporal/worker_deployment_test.go
@@ -72,7 +72,7 @@ func TestVersionInfoFromVersionSummaryLogsRoutingConfigStatusConflicts(t *testin
 				context.Background(), logger, nil, "", "", nil, tt.routingConfig, summary,
 			)
 
-			assert.NotEqual(t, tt.reportedStatus, info.Status)
+			assert.Equal(t, tt.reportedStatus, info.Status)
 			logs := strings.Join(logLines, "\n")
 			assert.Contains(t, logs, tt.expectedLogMessage)
 			assert.Contains(t, logs, "build-a")

--- a/internal/temporal/worker_deployment_test.go
+++ b/internal/temporal/worker_deployment_test.go
@@ -17,6 +17,20 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 )
 
+func TestVersionStatusMap(t *testing.T) {
+	tests := map[enumspb.WorkerDeploymentVersionStatus]temporaliov1alpha1.VersionStatus{
+		enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_UNSPECIFIED: temporaliov1alpha1.VersionStatusNotRegistered,
+		enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_CREATED:     temporaliov1alpha1.VersionStatusCreated,
+		enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_INACTIVE:    temporaliov1alpha1.VersionStatusInactive,
+		enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_RAMPING:     temporaliov1alpha1.VersionStatusRamping,
+		enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_CURRENT:     temporaliov1alpha1.VersionStatusCurrent,
+		enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_DRAINING:    temporaliov1alpha1.VersionStatusDraining,
+		enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_DRAINED:     temporaliov1alpha1.VersionStatusDrained,
+	}
+
+	assert.Equal(t, tests, versionStatusMap)
+}
+
 func TestVersionInfoFromVersionSummaryLogsRoutingConfigStatusConflicts(t *testing.T) {
 	tests := []struct {
 		name                  string

--- a/internal/tests/internal/rate_limit_integration_test.go
+++ b/internal/tests/internal/rate_limit_integration_test.go
@@ -19,7 +19,7 @@ import (
 // runRateLimitTest verifies that when multiple TWDs in the same Temporal namespace
 // burst-reconcile concurrently against a 1 RPS DescribeWorkerDeployment limit, the
 // controller surfaces the error as ConditionProgressing=False with
-// ReasonTemporalStateFetchFailed and a "Rate limited" message.
+// ReasonTemporalStateFetchFailed and a ResourceExhausted message.
 //
 // The server passed in must have frontend.globalNamespaceWorkerDeploymentReadRPS=1.
 // With 10 TWDs each reconciling every 1s (RECONCILE_INTERVAL=1s set by setupTestEnvironment),
@@ -68,7 +68,7 @@ func runRateLimitTest(
 
 		// With 10 TWDs reconciling concurrently every 1s and a 1 RPS limit, most will be
 		// rate-limited almost immediately. Verify at least one surfaces the error with the
-		// expected condition reason and "Rate limited" message (set by our ResourceExhausted
+		// expected condition reason and ResourceExhausted message (set by our ResourceExhausted
 		// handler in worker_controller.go).
 		eventually(t, 30*time.Second, time.Second, func() error {
 			for _, twd := range twds {
@@ -83,13 +83,13 @@ func runRateLimitTest(
 					if c.Type == temporaliov1alpha1.ConditionProgressing &&
 						c.Status == metav1.ConditionFalse &&
 						c.Reason == temporaliov1alpha1.ReasonTemporalStateFetchFailed &&
-						strings.Contains(c.Message, "Rate limited") {
+						strings.Contains(c.Message, "Got ResourceExhausted error") {
 						t.Logf("TWD %s confirmed rate-limited: %s", twd.Name, c.Message)
 						return nil
 					}
 				}
 			}
-			return errors.New("no TWD has been rate-limited yet")
+			return errors.New("no TWD has surfaced a ResourceExhausted error yet")
 		})
 	})
 }


### PR DESCRIPTION
## What was changed
- Make controller more resilient to inconsistent Temporal state (actually check version status instead of just deducing it from routing config)
- delay requeue after Temporal ResourceExhausted
- improve "scaling" log by including build id tag

## Why?
- Server race condition where async SetCurrent could still be in progress when Describe request is served so routing config is out of sync with version summaries.
- no need to requeue so fast
- want to know what is being scaled

Closes #555