### PR TITLE
helm: document extraEnv proxy usage and validate EnvVar shape

### DIFF
--- a/.github/workflows/helm-validate.yml
+++ b/.github/workflows/helm-validate.yml
@@ -62,6 +62,29 @@ jobs:
           helm template test-release helm/temporal-worker-controller \
             --set 'rbac.restrictWatchNamespaces={ns-a,ns-b}'
 
+      - name: Template with extra manager environment variables
+        run: |
+          set -euo pipefail
+          rendered=$(helm template test-release helm/temporal-worker-controller \
+            --set-string 'extraEnv[0].name=HTTP_PROXY' \
+            --set-string 'extraEnv[0].value=http://proxy.example.com:8080' \
+            --set-string 'extraEnv[1].name=API_TOKEN' \
+            --set-string 'extraEnv[1].valueFrom.secretKeyRef.name=controller-secrets' \
+            --set-string 'extraEnv[1].valueFrom.secretKeyRef.key=api-token')
+          echo "$rendered" | grep -q 'name: HTTP_PROXY'
+          echo "$rendered" | grep -q 'value: http://proxy.example.com:8080'
+          echo "$rendered" | grep -q 'name: API_TOKEN'
+          echo "$rendered" | grep -q 'name: controller-secrets'
+          echo "$rendered" | grep -q 'key: api-token'
+
+      - name: Reject extraEnv entries without a name
+        run: |
+          if helm template test-release helm/temporal-worker-controller \
+            --set-string 'extraEnv[0].value=http://proxy.example.com:8080'; then
+            echo "expected helm template to fail when extraEnv is missing name" >&2
+            exit 1
+          fi
+
       - name: Template with end user roles disabled
         run: |
           helm template test-release helm/temporal-worker-controller \

--- a/helm/temporal-worker-controller/values.schema.json
+++ b/helm/temporal-worker-controller/values.schema.json
@@ -255,9 +255,27 @@
     },
     "extraEnv": {
       "default": [],
-      "description": "Additional environment variables for the manager container.\n\nUse this with extraVolumes and extraVolumeMounts to trust a private certificate authority. The controller verifies the Temporal server certificate against the system trust store, so an internally-issued endpoint fails with \"x509: certificate signed by unknown authority\". The controller is written in Go, which reads SSL_CERT_FILE.\n\nFor example:\nextraEnv:\n- name: SSL_CERT_FILE\n  value: /etc/ssl/custom-ca/ca.crt",
+      "description": "Additional Kubernetes EnvVar entries for the manager container. Each entry needs a name and either a literal value or a valueFrom source.\n\nUse this for corporate HTTP(S) proxies (HTTP_PROXY, HTTPS_PROXY, NO_PROXY) — the Go runtime, gRPC, and net/http honor those variables. Use it with extraVolumes and extraVolumeMounts to trust a private CA via SSL_CERT_FILE.\n\nFor example:\nextraEnv:\n- name: HTTP_PROXY\n  value: http://proxy.corp.example.com:8080\n- name: SSL_CERT_FILE\n  value: /etc/ssl/custom-ca/ca.crt\n- name: API_TOKEN\n  valueFrom:\n    secretKeyRef:\n      name: controller-secrets\n      key: api-token",
       "items": {
-        "type": "object"
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Environment variable name"
+          },
+          "value": {
+            "type": "string",
+            "description": "Literal environment variable value"
+          },
+          "valueFrom": {
+            "type": "object",
+            "description": "Kubernetes EnvVarSource, such as secretKeyRef or configMapKeyRef"
+          }
+        }
       },
       "type": "array"
     },

--- a/helm/temporal-worker-controller/values.yaml
+++ b/helm/temporal-worker-controller/values.yaml
@@ -185,20 +185,29 @@ nodeSelector: {}
 
 tolerations: []
 
-# extraEnv adds environment variables to the manager container.
+# extraEnv adds Kubernetes EnvVar entries to the manager container. Each entry
+# needs a name and either a literal value or a valueFrom source
+# (secretKeyRef / configMapKeyRef). The Go runtime, gRPC (Temporal SDK), and
+# net/http (controller-runtime / client-go) honor standard proxy variables.
 #
-# Use this together with extraVolumes/extraVolumeMounts to trust a private
-# certificate authority. The controller connects to Temporal as a gRPC client and
-# verifies the server certificate against the system trust store, so a self-signed
-# or internally-issued endpoint fails with:
-#   transport: authentication handshake failed: tls: failed to verify certificate:
-#   x509: certificate signed by unknown authority
-# The controller is written in Go, which reads SSL_CERT_FILE, so mounting the CA and
-# pointing SSL_CERT_FILE at it is sufficient.
+# Use extraVolumes/extraVolumeMounts together with SSL_CERT_FILE to trust a
+# private CA. The controller verifies the Temporal server certificate against
+# the system trust store; Go reads SSL_CERT_FILE.
 #
 # extraEnv:
+#   - name: HTTP_PROXY
+#     value: "http://proxy.corp.example.com:8080"
+#   - name: HTTPS_PROXY
+#     value: "http://proxy.corp.example.com:8080"
+#   - name: NO_PROXY
+#     value: "localhost,127.0.0.1,.svc,.cluster.local,10.0.0.0/8"
 #   - name: SSL_CERT_FILE
 #     value: /etc/ssl/custom-ca/ca.crt
+#   - name: API_TOKEN
+#     valueFrom:
+#       secretKeyRef:
+#         name: controller-secrets
+#         key: api-token
 extraEnv: []
 
 # extraVolumes adds volumes to the manager pod, alongside the webhook certificate


### PR DESCRIPTION
extraEnv already exists; document the corporate-proxy and valueFrom cases, require a name in the chart schema, and cover both in Helm CI.

<!--- For ALL Contributors 👇 -->

## What was changed
`extraEnv` already exists on the manager container (added in #532). This PR documents the corporate-proxy and `valueFrom` cases from #510, requires each entry to have a non-empty `name` in `values.schema.json`, and adds Helm CI coverage that extraEnv renders (literal + secret ref) and that a nameless entry is rejected.

## Why?
Operators behind a corporate proxy need to pass `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` into the manager. The Go runtime, gRPC, and net/http already honor those variables, but #510 stayed open because the chart only documented `SSL_CERT_FILE` and did not validate or test the EnvVar shape.

## Checklist
<!--- add/delete as needed --->
1. Closes #510
2. How was this tested:
- `helm template test-release helm/temporal-worker-controller | grep HTTP_PROXY` prints nothing (empty extraEnv does not leak proxy vars)
- `helm template` with `extraEnv` `HTTP_PROXY` + secret-backed `API_TOKEN` renders both on the manager container after the chart-owned env vars
- `helm template` with `extraEnv[0].value` and no `name` fails schema validation (`missing property 'name'`)
- `helm lint --strict helm/temporal-worker-controller` passes
3. Any docs updates needed?
No external docs. `values.yaml` and `values.schema.json` now include the proxy and `valueFrom` examples.



