### PR TITLE
Revert "Bump chart version to 0.28.1 [skip ci]"

### DIFF
--- a/helm/temporal-worker-controller-crds/Chart.yaml
+++ b/helm/temporal-worker-controller-crds/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: temporal-worker-controller-crds
 description: CRDs for the Temporal Worker Controller. Install this chart before the temporal-worker-controller chart.
 type: application
-version: 0.28.1
+version: 0.28.0

--- a/helm/temporal-worker-controller/Chart.yaml
+++ b/helm/temporal-worker-controller/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: temporal-worker-controller
 description: A Helm chart for the Temporal Worker Controller
 type: application
-version: 0.28.1
-appVersion: 1.7.1
+version: 0.28.0
+appVersion: 1.9.0
 dependencies:
   - name: cert-manager
     version: ">=v1.0.0"


### PR DESCRIPTION
This reverts commit 08f57c8c86fad913fbed0cb143256aa555d0e67b.

When we cut the emergency 1.7.1 TWC patch release over the weekend, the release automation erroneously updated the `main` Chart.yaml's `version` and `appVersion`.