### PR TITLE
fix(controller): skip ClusterConnection watch when namespace-scoped

### DIFF
--- a/api/v1alpha1/workerdeployment_types.go
+++ b/api/v1alpha1/workerdeployment_types.go
@@ -139,6 +139,11 @@ const (
 	// referenced Connection resource cannot be found.
 	ReasonConnectionNotFound = "ConnectionNotFound"
 
+	// ReasonClusterConnectionUnsupported is set on ConditionProgressing=False when a
+	// WorkerDeployment references a ClusterConnection but the controller is namespace-scoped.
+	// ClusterConnection is cluster-scoped, so such a controller can never read it.
+	ReasonClusterConnectionUnsupported = "ClusterConnectionUnsupported"
+
 	// ReasonAuthSecretInvalid is set on ConditionProgressing=False when the credential
 	// secret referenced by the Connection is misconfigured. This covers:
 	// (1) the secret reference has an empty name, (2) the named Kubernetes Secret

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -71,8 +71,10 @@ func main() {
 	//ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 	ctrl.SetLogger(zap.New(zap.JSONEncoder()))
 
-	if len(namespaces) > 0 {
+	namespaceScoped := len(namespaces) > 0
+	if namespaceScoped {
 		setupLog.Info("running controller in namespace-scoped mode", "namespaces", namespaces)
+		setupLog.Info("skipping ClusterConnection watches")
 	}
 
 	cacheOptions, err := controller.NewCacheOptions(namespaces)
@@ -142,6 +144,7 @@ func main() {
 		Recorder: mgr.GetEventRecorderFor("temporal-worker-controller"),
 		MaxDeploymentVersionsIneligibleForDeletion: controller.GetControllerMaxDeploymentVersionsIneligibleForDeletion(),
 		DisableDeprecatedTWD:                       !deprecatedCRDWatches.TemporalWorkerDeployments,
+		DisableClusterConnections:                  namespaceScoped,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "WorkerDeployment")
 		os.Exit(1)

--- a/internal/controller/clusterconnection_test.go
+++ b/internal/controller/clusterconnection_test.go
@@ -10,8 +10,10 @@ import (
 	temporaliov1alpha1 "github.com/temporalio/temporal-worker-controller/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -535,4 +537,83 @@ func TestSameConnectionRef(t *testing.T) {
 			assert.Equal(t, tc.want, sameConnectionRef(tc.a, tc.b))
 		})
 	}
+}
+
+// TestReconcile_ClusterConnectionNamespaceScoped covers the namespace-scoped controller,
+// which cannot read cluster-scoped resources and so cannot support ClusterConnection.
+func TestReconcile_ClusterConnectionNamespaceScoped(t *testing.T) {
+	ctx := context.Background()
+	key := func(wd *temporaliov1alpha1.WorkerDeployment) types.NamespacedName {
+		return types.NamespacedName{Name: wd.Name, Namespace: wd.Namespace}
+	}
+
+	t.Run("clusterRef_blockedWithClearReason", func(t *testing.T) {
+		cc := makeClusterConnection("conn", "h:7233")
+		wd := makeWDWithKind("wd", "default", "conn", "ClusterConnection")
+		r, recorder := newTestReconciler([]client.Object{cc, wd})
+		r.DisableClusterConnections = true
+
+		result, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: key(wd)})
+		require.NoError(t, err)
+		assert.Zero(t, result.RequeueAfter, "must not requeue: only a spec or deployment-mode change can resolve this")
+
+		assertEventEmitted(t, drainEvents(recorder), temporaliov1alpha1.ReasonClusterConnectionUnsupported)
+
+		var updated temporaliov1alpha1.WorkerDeployment
+		require.NoError(t, r.Get(ctx, key(wd), &updated))
+		for _, condType := range []string{
+			temporaliov1alpha1.ConditionProgressing,
+			temporaliov1alpha1.ConditionReady,
+			temporaliov1alpha1.ConditionConnectionHealthy, //nolint:staticcheck // backward compat
+		} {
+			cond := meta.FindStatusCondition(updated.Status.Conditions, condType)
+			require.NotNil(t, cond, "%s should be set", condType)
+			assert.Equal(t, metav1.ConditionFalse, cond.Status, condType)
+			assert.Equal(t, temporaliov1alpha1.ReasonClusterConnectionUnsupported, cond.Reason, condType)
+		}
+
+		assert.False(t, controllerutil.ContainsFinalizer(&updated, finalizerName),
+			"WorkerDeployment must stay deletable: it holds no Temporal state to clean up")
+	})
+
+	// The namespaced Connection path must be untouched by the flag.
+	t.Run("namespacedRef_unaffected", func(t *testing.T) {
+		wd := makeWDWithKind("wd", "default", "missing", "Connection")
+		r, recorder := newTestReconciler([]client.Object{wd})
+		r.DisableClusterConnections = true
+
+		_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: key(wd)})
+		require.Error(t, err, "expected the usual ConnectionNotFound failure")
+
+		events := drainEvents(recorder)
+		assertEventEmitted(t, events, temporaliov1alpha1.ReasonConnectionNotFound)
+		assertNoEventEmitted(t, events, temporaliov1alpha1.ReasonClusterConnectionUnsupported)
+	})
+
+	// A cluster-scoped controller keeps resolving ClusterConnection as before.
+	t.Run("clusterRef_notBlockedWhenClusterScoped", func(t *testing.T) {
+		wd := makeWDWithKind("wd", "default", "missing", "ClusterConnection")
+		r, recorder := newTestReconciler([]client.Object{wd})
+
+		_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: key(wd)})
+		require.Error(t, err, "expected the usual ConnectionNotFound failure")
+
+		assertNoEventEmitted(t, drainEvents(recorder), temporaliov1alpha1.ReasonClusterConnectionUnsupported)
+	})
+}
+
+// A namespace-scoped controller never added a finalizer to a ClusterConnection, so releasing
+// one must be a no-op rather than a read it is not allowed to perform.
+func TestReleaseConnectionFinalizerIfUnused_NamespaceScoped(t *testing.T) {
+	cc := makeClusterConnection("conn", "h:7233")
+	controllerutil.AddFinalizer(cc, finalizerName)
+	wd := makeWDWithKind("wd", "default", "conn", "ClusterConnection")
+	r, _ := newTestReconciler([]client.Object{cc, wd})
+	r.DisableClusterConnections = true
+
+	require.NoError(t, r.releaseConnectionFinalizerIfUnused(
+		context.Background(), logr.Discard(), wd.Spec.WorkerOptions.ConnectionRef, wd.Namespace, wd.Name))
+
+	assert.True(t, hasFinalizer(t, r.Client, &temporaliov1alpha1.ClusterConnection{},
+		types.NamespacedName{Name: "conn"}), "the ClusterConnection must be left untouched")
 }

--- a/internal/controller/worker_controller.go
+++ b/internal/controller/worker_controller.go
@@ -67,6 +67,11 @@ type WorkerDeploymentReconciler struct {
 	DisableRecoverPanic  bool
 	DisableDeprecatedTWD bool
 
+	// DisableClusterConnections drops ClusterConnection support. Set when the manager is
+	// namespace-scoped: ClusterConnection is cluster-scoped, so a namespaced Role can never
+	// authorize listing it and the watch would retry forever against a 403.
+	DisableClusterConnections bool
+
 	// When a Worker Deployment has the maximum number of versions (100 per Worker Deployment by default),
 	// it will delete the oldest eligible version when a worker with the 101st version arrives.
 	// If no versions are eligible for deletion, that worker's poll will fail, which is dangerous.
@@ -185,6 +190,17 @@ func (r *WorkerDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			}
 			l.Info("Temporal server-side cleanup complete, finalizer removed")
 		}
+		return ctrl.Result{}, nil
+	}
+
+	// This WorkerDeployment can never reconcile. Reported before the finalizer is added so it
+	// stays deletable, and without requeueing since only a spec or deployment-mode change can
+	// resolve it.
+	if r.DisableClusterConnections && connectionRefIsCluster(workerDeploy.Spec.WorkerOptions.ConnectionRef) {
+		msg := fmt.Sprintf("ClusterConnection %q cannot be used because the controller is namespace-scoped",
+			connectionRefName(workerDeploy.Spec.WorkerOptions.ConnectionRef))
+		r.recordWarningAndSetBlocked(ctx, &workerDeploy,
+			temporaliov1alpha1.ReasonClusterConnectionUnsupported, msg, msg)
 		return ctrl.Result{}, nil
 	}
 
@@ -813,6 +829,7 @@ func (r *WorkerDeploymentReconciler) recordWarningAndSetBlocked(
 	// failures are unrelated to connection health and should not trigger this condition.
 	switch reason {
 	case temporaliov1alpha1.ReasonConnectionNotFound,
+		temporaliov1alpha1.ReasonClusterConnectionUnsupported,
 		temporaliov1alpha1.ReasonAuthSecretInvalid,
 		temporaliov1alpha1.ReasonTemporalClientCreationFailed,
 		temporaliov1alpha1.ReasonTemporalStateFetchFailed:
@@ -896,6 +913,12 @@ func (r *WorkerDeploymentReconciler) releaseConnectionFinalizerIfUnused(
 	selfNamespace, selfName string,
 ) error {
 	isCluster := connectionRefIsCluster(ref)
+
+	// A namespace-scoped controller never placed a finalizer on a ClusterConnection, and
+	// cannot read one to check. Nothing to release.
+	if isCluster && r.DisableClusterConnections {
+		return nil
+	}
 
 	// Scope the "is it still used?" query correctly for the kind:
 	//   - Namespaced Connection: only WDs in its own namespace can reference it,
@@ -992,8 +1015,10 @@ func (r *WorkerDeploymentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&temporaliov1alpha1.WorkerDeployment{}).
 		Owns(&appsv1.Deployment{}).
 		Watches(&temporaliov1alpha1.Connection{}, handler.EnqueueRequestsFromMapFunc(r.findTWDsUsingConnection)).
-		Watches(&temporaliov1alpha1.ClusterConnection{}, handler.EnqueueRequestsFromMapFunc(r.findTWDsUsingClusterConnection)).
 		Watches(&temporaliov1alpha1.WorkerResourceTemplate{}, handler.EnqueueRequestsFromMapFunc(r.reconcileRequestForWRT))
+	if !r.DisableClusterConnections {
+		builder = builder.Watches(&temporaliov1alpha1.ClusterConnection{}, handler.EnqueueRequestsFromMapFunc(r.findTWDsUsingClusterConnection))
+	}
 	if !r.DisableDeprecatedTWD {
 		// Watch deprecated TemporalWorkerDeployments so that any modification to an existing TWD
 		// (e.g. a status update before migration completes) triggers a reconcile of the matching WD


### PR DESCRIPTION
Skip the `ClusterConnection` watch when the controller is namespace-scoped.

`ClusterConnection` (added in #549) is the only cluster-scoped CRD in the set, but the watch is
registered unconditionally. An install with `rbac.restrictWatchNamespaces` gets a namespaced
`Role`, which can never authorize it, so the controller logs this on every retry, per namespace,
forever:

```
Failed to watch *v1alpha1.ClusterConnection: failed to list *v1alpha1.ClusterConnection:
clusterconnections.temporal.io is forbidden: User "system:serviceaccount:<ns>:<sa>" cannot
list resource "clusterconnections" in API group "temporal.io" at the cluster scope
```

Reconciliation is unaffected, so this is log noise and alert pressure rather than an outage.